### PR TITLE
fix: prettier format spec, backend delete test assertion, CI chromium…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
           echo "Next.js is ready"
 
       - name: Run Playwright E2E tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --project=chromium
         env:
           BASE_URL: http://localhost:3000
           CYPRESS_ADMIN_USERNAME: ${{ secrets.CYPRESS_ADMIN_USERNAME }}

--- a/backend/src/test/java/com/pm4/istp/controller/AdminConfigurationControllerTest.java
+++ b/backend/src/test/java/com/pm4/istp/controller/AdminConfigurationControllerTest.java
@@ -166,7 +166,7 @@ class AdminConfigurationControllerTest {
     void testDeleteAdminConfig_Success() throws Exception {
         mockMvc.perform(delete("/api/admin/config"))
                 .andExpect(status().isOk())
-                .andExpect(content().string("Admin configuration deleted successfully"));
+                .andExpect(jsonPath("$.message").value("Admin configuration deleted successfully"));
 
         verify(adminConfigurationService).deleteAdminConfiguration();
     }

--- a/frontend/tests/admin-config.spec.ts
+++ b/frontend/tests/admin-config.spec.ts
@@ -42,8 +42,9 @@ test.describe.serial("Admin configuration", () => {
     await page.getByRole("option", { name: "Mi" }).click();
     await page.getByRole("button", { name: "Kubeconfig" }).click();
     await page.locator('input[type="file"]').setInputFiles("tests/files/Kubeconfig_Variant_1");
-    await expectApiSuccess(page, () =>
-      page.getByRole("button", { name: "Create Kubernetes configuration" }).click(),
+    await expectApiSuccess(
+      page,
+      () => page.getByRole("button", { name: "Create Kubernetes configuration" }).click(),
       /\/api\/admin\//
     );
   });
@@ -55,8 +56,9 @@ test.describe.serial("Admin configuration", () => {
     await page.getByRole("textbox", { name: "Memory limit" }).fill("1");
     await page.getByRole("combobox", { name: "Memory unit" }).click();
     await page.getByRole("option", { name: "Gi" }).click();
-    await expectApiSuccess(page, () =>
-      page.getByRole("button", { name: "Update Kubernetes configuration" }).click(),
+    await expectApiSuccess(
+      page,
+      () => page.getByRole("button", { name: "Update Kubernetes configuration" }).click(),
       /\/api\/admin\//
     );
   });
@@ -64,8 +66,9 @@ test.describe.serial("Admin configuration", () => {
   test("update kubeconfig file", async ({ page }) => {
     await page.getByRole("button", { name: "Kubeconfig" }).click();
     await page.locator('input[type="file"]').setInputFiles("tests/files/Kubeconfig_Variant_2");
-    await expectApiSuccess(page, () =>
-      page.getByRole("button", { name: "Update Kubernetes configuration" }).click(),
+    await expectApiSuccess(
+      page,
+      () => page.getByRole("button", { name: "Update Kubernetes configuration" }).click(),
       /\/api\/admin\//
     );
   });


### PR DESCRIPTION
…-only E2E

- Run prettier on tests/admin-config.spec.ts to fix format:check failure
- Fix testDeleteAdminConfig_Success to expect JSON {message:...} instead of plain string
- Add --project=chromium to CI playwright test command (Issue 3)"

Agent-Logs-Url: https://github.com/PM4-ISTP/PM4-IT24aWIN-ISTP/sessions/d78cde39-c97e-4d7c-a85a-edc881050253