### PR TITLE
Add public team endpoint and frontend UI

### DIFF
--- a/backend/src/main/java/com/pm4/istp/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pm4/istp/config/SecurityConfig.java
@@ -36,6 +36,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/v3/api-docs/**", "/v3/api-docs.yaml")
                     .permitAll()
+                    .requestMatchers("/api/v1/public/**")
+                    .permitAll()
                     .requestMatchers("/api/v1/courses/catalog")
                     .authenticated()
                     .requestMatchers("/api/v1/courses/catalog/**")

--- a/backend/src/main/java/com/pm4/istp/controller/PublicController.java
+++ b/backend/src/main/java/com/pm4/istp/controller/PublicController.java
@@ -4,6 +4,7 @@ import com.pm4.istp.dto.PublicTeamMemberDto;
 import com.pm4.istp.mappers.UserMapper;
 import com.pm4.istp.service.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,12 +22,16 @@ public class PublicController {
   private final UserService userService;
   private final UserMapper userMapper;
 
-  @Value("${team.emails}")
+  @Value("${team.emails:}")
   private String teamEmailsRaw;
 
   @GetMapping("/team")
   public ResponseEntity<List<PublicTeamMemberDto>> getTeamMembers() {
-    List<String> emails = List.of(teamEmailsRaw.split(","));
+    List<String> emails =
+        Arrays.stream(teamEmailsRaw.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .toList();
     List<PublicTeamMemberDto> team =
         userService.getTeamMembers(emails).stream()
             .map(userMapper::toPublicTeamMemberDto)

--- a/backend/src/main/java/com/pm4/istp/controller/PublicController.java
+++ b/backend/src/main/java/com/pm4/istp/controller/PublicController.java
@@ -1,0 +1,36 @@
+package com.pm4.istp.controller;
+
+import com.pm4.istp.dto.PublicTeamMemberDto;
+import com.pm4.istp.mappers.UserMapper;
+import com.pm4.istp.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Public", description = "Unauthenticated public endpoints")
+@RestController
+@RequestMapping("/api/v1/public")
+@RequiredArgsConstructor
+public class PublicController {
+
+  private final UserService userService;
+  private final UserMapper userMapper;
+
+  @Value("${team.emails}")
+  private String teamEmailsRaw;
+
+  @GetMapping("/team")
+  public ResponseEntity<List<PublicTeamMemberDto>> getTeamMembers() {
+    List<String> emails = List.of(teamEmailsRaw.split(","));
+    List<PublicTeamMemberDto> team =
+        userService.getTeamMembers(emails).stream()
+            .map(userMapper::toPublicTeamMemberDto)
+            .toList();
+    return ResponseEntity.ok(team);
+  }
+}

--- a/backend/src/main/java/com/pm4/istp/dto/PublicTeamMemberDto.java
+++ b/backend/src/main/java/com/pm4/istp/dto/PublicTeamMemberDto.java
@@ -1,0 +1,14 @@
+package com.pm4.istp.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PublicTeamMemberDto {
+  private String name;
+  private String picture;
+  private String title;
+}

--- a/backend/src/main/java/com/pm4/istp/mappers/UserMapper.java
+++ b/backend/src/main/java/com/pm4/istp/mappers/UserMapper.java
@@ -2,6 +2,7 @@ package com.pm4.istp.mappers;
 
 import com.pm4.istp.domain.entites.User;
 import com.pm4.istp.dto.ListInstructorUserResponseDto;
+import com.pm4.istp.dto.PublicTeamMemberDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
@@ -9,4 +10,6 @@ import org.mapstruct.ReportingPolicy;
 public interface UserMapper {
 
   ListInstructorUserResponseDto toListInstructorUserResponseDto(User user);
+
+  PublicTeamMemberDto toPublicTeamMemberDto(User user);
 }

--- a/backend/src/main/java/com/pm4/istp/repositories/UserRepository.java
+++ b/backend/src/main/java/com/pm4/istp/repositories/UserRepository.java
@@ -2,6 +2,8 @@ package com.pm4.istp.repositories;
 
 import com.pm4.istp.domain.entites.User;
 import com.pm4.istp.domain.entites.UserRoleEnum;
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -55,4 +57,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
       @Param("query") String query,
       @Param("userId") UUID userId,
       Pageable pageable);
+
+  List<User> findByEmailIn(Collection<String> emails);
 }

--- a/backend/src/main/java/com/pm4/istp/service/UserService.java
+++ b/backend/src/main/java/com/pm4/istp/service/UserService.java
@@ -1,6 +1,8 @@
 package com.pm4.istp.service;
 
 import com.pm4.istp.domain.entites.User;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +13,6 @@ public interface UserService {
   Page<User> searchCollaboratorUsersByName(UUID userId, String name, Pageable pageable);
 
   Page<User> searchCollaboratorUsersByQuery(UUID userId, String query, Pageable pageable);
+
+  List<User> getTeamMembers(Collection<String> emails);
 }

--- a/backend/src/main/java/com/pm4/istp/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/pm4/istp/service/impl/UserServiceImpl.java
@@ -4,6 +4,8 @@ import com.pm4.istp.domain.entites.User;
 import com.pm4.istp.domain.entites.UserRoleEnum;
 import com.pm4.istp.repositories.UserRepository;
 import com.pm4.istp.service.UserService;
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -35,5 +37,10 @@ public class UserServiceImpl implements UserService {
   public Page<User> searchCollaboratorUsersByQuery(UUID userId, String query, Pageable pageable) {
     return userRepository.findDistinctByAnyRoleAndNameOrUsernameOrEmailContainingIgnoreCaseAndIdNot(
         COURSE_COLLABORATOR_ROLES, query, userId, pageable);
+  }
+
+  @Override
+  public List<User> getTeamMembers(Collection<String> emails) {
+    return userRepository.findByEmailIn(emails);
   }
 }

--- a/backend/src/main/java/com/pm4/istp/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/pm4/istp/service/impl/UserServiceImpl.java
@@ -41,6 +41,9 @@ public class UserServiceImpl implements UserService {
 
   @Override
   public List<User> getTeamMembers(Collection<String> emails) {
+    if (emails.isEmpty()) {
+      return List.of();
+    }
     return userRepository.findByEmailIn(emails);
   }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -30,3 +30,6 @@ istp.tls=${ISTP_TLS:false}
 
 # CORS
 cors.allowed-origin=${CORS_ALLOWED_ORIGIN:http://localhost:3000}
+
+# Team members shown on the public homepage (comma-separated emails)
+team.emails=${TEAM_EMAILS:}

--- a/backend/src/test/java/com/pm4/istp/controller/PublicControllerTest.java
+++ b/backend/src/test/java/com/pm4/istp/controller/PublicControllerTest.java
@@ -1,0 +1,114 @@
+package com.pm4.istp.controller;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.pm4.istp.domain.entites.User;
+import com.pm4.istp.dto.PublicTeamMemberDto;
+import com.pm4.istp.mappers.UserMapper;
+import com.pm4.istp.service.UserService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class PublicControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private PublicController publicController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(publicController).build();
+    }
+
+    @Test
+    void getTeamMembers_returnsEmptyList_whenEmailsNotConfigured() throws Exception {
+        ReflectionTestUtils.setField(publicController, "teamEmailsRaw", "");
+        when(userService.getTeamMembers(List.of())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/public/team"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void getTeamMembers_returnsMembers_whenEmailsConfigured() throws Exception {
+        ReflectionTestUtils.setField(publicController, "teamEmailsRaw", "alice@example.com , bob@example.com");
+
+        User alice = new User();
+        alice.setId(UUID.randomUUID());
+        alice.setName("Alice");
+        alice.setEmail("alice@example.com");
+
+        User bob = new User();
+        bob.setId(UUID.randomUUID());
+        bob.setName("Bob");
+        bob.setEmail("bob@example.com");
+
+        PublicTeamMemberDto aliceDto = new PublicTeamMemberDto("Alice", null, "Developer");
+        PublicTeamMemberDto bobDto = new PublicTeamMemberDto("Bob", null, "Designer");
+
+        when(userService.getTeamMembers(List.of("alice@example.com", "bob@example.com")))
+                .thenReturn(List.of(alice, bob));
+        when(userMapper.toPublicTeamMemberDto(alice)).thenReturn(aliceDto);
+        when(userMapper.toPublicTeamMemberDto(bob)).thenReturn(bobDto);
+
+        mockMvc.perform(get("/api/v1/public/team"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].name").value("Alice"))
+                .andExpect(jsonPath("$[1].name").value("Bob"));
+    }
+
+    @Test
+    void getTeamMembers_trimsWhitespaceAndFiltersBlankEmails() throws Exception {
+        ReflectionTestUtils.setField(publicController, "teamEmailsRaw", " alice@example.com , , bob@example.com ");
+
+        User alice = new User();
+        alice.setId(UUID.randomUUID());
+        alice.setName("Alice");
+        alice.setEmail("alice@example.com");
+
+        PublicTeamMemberDto aliceDto = new PublicTeamMemberDto("Alice", null, null);
+
+        when(userService.getTeamMembers(List.of("alice@example.com", "bob@example.com")))
+                .thenReturn(List.of(alice));
+        when(userMapper.toPublicTeamMemberDto(alice)).thenReturn(aliceDto);
+
+        mockMvc.perform(get("/api/v1/public/team"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("Alice"));
+    }
+
+    @Test
+    void getTeamMembers_isAccessibleWithoutAuthentication() throws Exception {
+        ReflectionTestUtils.setField(publicController, "teamEmailsRaw", "");
+        when(userService.getTeamMembers(anyList())).thenReturn(List.of());
+
+        // No auth header provided — endpoint should return 200, not 401/403
+        mockMvc.perform(get("/api/v1/public/team"))
+                .andExpect(status().isOk());
+    }
+}

--- a/frontend/src/app/api/public/team/route.ts
+++ b/frontend/src/app/api/public/team/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const backendUrl = process.env.BACKEND_URL || "http://localhost:8080";
+    const res = await fetch(`${backendUrl}/api/v1/public/team`, {
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return NextResponse.json([]);
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json([]);
+  }
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,6 +3,7 @@ import { authOptions } from "@/src/lib/auth";
 import { redirect } from "next/navigation";
 import { Box, Container, Stack, Title, Text, Badge } from "@mantine/core";
 import Login from "@/src/components/Login";
+import { TeamSection } from "@/src/components/TeamSection";
 
 const heroBackground = "linear-gradient(160deg, #0b1120 0%, #0e1a2e 45%, #0b1624 100%)";
 
@@ -151,6 +152,9 @@ export default async function Home() {
               <Login />
             </Stack>
           </div>
+
+          {/* Team */}
+          <TeamSection />
         </Stack>
       </Container>
 

--- a/frontend/src/components/TeamSection.tsx
+++ b/frontend/src/components/TeamSection.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AnimatedTooltip } from "@/src/components/ui/animated-tooltip";
+
+interface TeamMember {
+  name: string;
+  picture: string | null;
+  title: string | null;
+}
+
+export function TeamSection() {
+  const [people, setPeople] = useState<{ id: number; name: string; designation: string; image: string }[]>([]);
+
+  useEffect(() => {
+    fetch("/api/public/team")
+      .then((r) => r.ok ? r.json() : null)
+      .then((team: TeamMember[] | null) => {
+        if (!team || team.length === 0) return;
+        setPeople(
+          team.map((m, i) => ({
+            id: i + 1,
+            name: m.name,
+            designation: m.title || "Software Engineer",
+            image: m.picture || "",
+          }))
+        );
+      })
+      .catch(() => {});
+  }, []);
+
+  if (people.length === 0) return null;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12, marginTop: 8 }}>
+      <p
+        style={{
+          color: "rgba(255,255,255,0.2)",
+          fontSize: "0.7rem",
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          fontFamily: "var(--font-space-grotesk), sans-serif",
+          margin: 0,
+        }}
+      >
+        Built by
+      </p>
+      <AnimatedTooltip items={people} />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/animated-tooltip.tsx
+++ b/frontend/src/components/ui/animated-tooltip.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import { useState } from "react";
 
 export interface TooltipItem {
   id: number;
@@ -9,7 +9,7 @@ export interface TooltipItem {
 }
 
 export function AnimatedTooltip({ items }: { items: TooltipItem[] }) {
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [hoveredId, setHoveredId] = useState<number | null>(null);
 
   return (
     <div style={{ display: "flex", flexDirection: "row" }}>
@@ -17,17 +17,24 @@ export function AnimatedTooltip({ items }: { items: TooltipItem[] }) {
         <div
           key={item.id}
           style={{ position: "relative", marginLeft: idx === 0 ? 0 : -12 }}
-          onMouseEnter={() => setHoveredIndex(item.id)}
-          onMouseLeave={() => setHoveredIndex(null)}
+          tabIndex={0}
+          onMouseEnter={() => setHoveredId(item.id)}
+          onMouseLeave={() => setHoveredId(null)}
+          onFocus={() => setHoveredId(item.id)}
+          onBlur={() => setHoveredId(null)}
+          aria-describedby={hoveredId === item.id ? `tooltip-${item.id}` : undefined}
         >
           {/* Tooltip */}
           <div
+            id={`tooltip-${item.id}`}
+            role="tooltip"
+            aria-hidden={hoveredId !== item.id}
             style={{
               position: "absolute",
               bottom: "calc(100% + 10px)",
               left: "50%",
-              transform: `translateX(-50%) ${hoveredIndex === item.id ? "translateY(0) scale(1)" : "translateY(6px) scale(0.92)"}`,
-              opacity: hoveredIndex === item.id ? 1 : 0,
+              transform: `translateX(-50%) ${hoveredId === item.id ? "translateY(0) scale(1)" : "translateY(6px) scale(0.92)"}`,
+              opacity: hoveredId === item.id ? 1 : 0,
               pointerEvents: "none",
               transition: "all 0.2s cubic-bezier(0.34,1.56,0.64,1)",
               zIndex: 50,
@@ -88,19 +95,19 @@ export function AnimatedTooltip({ items }: { items: TooltipItem[] }) {
               height: 44,
               borderRadius: "50%",
               overflow: "hidden",
-              border: hoveredIndex === item.id
+              border: hoveredId === item.id
                 ? "2px solid #60a5fa"
                 : "2px solid rgba(255,255,255,0.15)",
-              transform: hoveredIndex === item.id ? "scale(1.12) translateY(-3px)" : "scale(1)",
+              transform: hoveredId === item.id ? "scale(1.12) translateY(-3px)" : "scale(1)",
               transition: "all 0.2s cubic-bezier(0.34,1.56,0.64,1)",
               cursor: "pointer",
               position: "relative",
-              zIndex: hoveredIndex === item.id ? 10 : idx,
+              zIndex: hoveredId === item.id ? 10 : idx,
               background: "rgba(96,165,250,0.08)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              boxShadow: hoveredIndex === item.id ? "0 0 0 3px rgba(96,165,250,0.25)" : "none",
+              boxShadow: hoveredId === item.id ? "0 0 0 3px rgba(96,165,250,0.25)" : "none",
             }}
           >
             {item.image ? (

--- a/frontend/src/components/ui/animated-tooltip.tsx
+++ b/frontend/src/components/ui/animated-tooltip.tsx
@@ -1,0 +1,131 @@
+"use client";
+import React, { useState } from "react";
+
+export interface TooltipItem {
+  id: number;
+  name: string;
+  designation: string;
+  image: string;
+}
+
+export function AnimatedTooltip({ items }: { items: TooltipItem[] }) {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "row" }}>
+      {items.map((item, idx) => (
+        <div
+          key={item.id}
+          style={{ position: "relative", marginLeft: idx === 0 ? 0 : -12 }}
+          onMouseEnter={() => setHoveredIndex(item.id)}
+          onMouseLeave={() => setHoveredIndex(null)}
+        >
+          {/* Tooltip */}
+          <div
+            style={{
+              position: "absolute",
+              bottom: "calc(100% + 10px)",
+              left: "50%",
+              transform: `translateX(-50%) ${hoveredIndex === item.id ? "translateY(0) scale(1)" : "translateY(6px) scale(0.92)"}`,
+              opacity: hoveredIndex === item.id ? 1 : 0,
+              pointerEvents: "none",
+              transition: "all 0.2s cubic-bezier(0.34,1.56,0.64,1)",
+              zIndex: 50,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {/* Arrow */}
+            <div
+              style={{
+                position: "absolute",
+                top: "100%",
+                left: "50%",
+                transform: "translateX(-50%)",
+                width: 0,
+                height: 0,
+                borderLeft: "5px solid transparent",
+                borderRight: "5px solid transparent",
+                borderTop: "5px solid #1e293b",
+              }}
+            />
+            <div
+              style={{
+                background: "linear-gradient(135deg, #1e293b 0%, #0f172a 100%)",
+                border: "1px solid rgba(96,165,250,0.2)",
+                borderRadius: 8,
+                padding: "6px 12px",
+                boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
+              }}
+            >
+              <p
+                style={{
+                  color: "#f1f5f9",
+                  fontWeight: 700,
+                  fontSize: "0.82rem",
+                  margin: 0,
+                  fontFamily: "var(--font-space-grotesk), sans-serif",
+                }}
+              >
+                {item.name}
+              </p>
+              <p
+                style={{
+                  color: "#60a5fa",
+                  fontSize: "0.72rem",
+                  margin: 0,
+                  fontFamily: "var(--font-space-grotesk), sans-serif",
+                }}
+              >
+                {item.designation}
+              </p>
+            </div>
+          </div>
+
+          {/* Avatar */}
+          <div
+            style={{
+              width: 44,
+              height: 44,
+              borderRadius: "50%",
+              overflow: "hidden",
+              border: hoveredIndex === item.id
+                ? "2px solid #60a5fa"
+                : "2px solid rgba(255,255,255,0.15)",
+              transform: hoveredIndex === item.id ? "scale(1.12) translateY(-3px)" : "scale(1)",
+              transition: "all 0.2s cubic-bezier(0.34,1.56,0.64,1)",
+              cursor: "pointer",
+              position: "relative",
+              zIndex: hoveredIndex === item.id ? 10 : idx,
+              background: "rgba(96,165,250,0.08)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              boxShadow: hoveredIndex === item.id ? "0 0 0 3px rgba(96,165,250,0.25)" : "none",
+            }}
+          >
+            {item.image ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={item.image}
+                alt={item.name}
+                style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              />
+            ) : (
+              <span
+                style={{
+                  color: "#60a5fa",
+                  fontWeight: 700,
+                  fontSize: "0.9rem",
+                  fontFamily: "var(--font-space-grotesk), sans-serif",
+                  userSelect: "none",
+                }}
+              >
+                {item.name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2)}
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Expose an unauthenticated public API and add a frontend team section. Backend: permit /api/v1/public/** in SecurityConfig; add PublicController (/api/v1/public/team) which reads team.emails config and returns a list of PublicTeamMemberDto; add DTO, mapper method, repository findByEmailIn, and service API/impl to fetch team members by email. Frontend: add a Next.js API route (/api/public/team) that proxies the backend (with 1h revalidate), a TeamSection component that loads team members and a reusable AnimatedTooltip avatar UI, and include the TeamSection on the homepage.