### PR TITLE
Disable cache and validate team API response

### DIFF
--- a/frontend/src/app/api/public/team/route.ts
+++ b/frontend/src/app/api/public/team/route.ts
@@ -4,7 +4,7 @@ export async function GET() {
   try {
     const backendUrl = process.env.BACKEND_URL || "http://localhost:8080";
     const res = await fetch(`${backendUrl}/api/v1/public/team`, {
-      next: { revalidate: 3600 },
+      cache: "no-store",
     });
     if (!res.ok) return NextResponse.json([]);
     const data: unknown = await res.json();

--- a/frontend/src/components/TeamSection.tsx
+++ b/frontend/src/components/TeamSection.tsx
@@ -17,7 +17,7 @@ function isTeamMemberArray(data: unknown): data is TeamMember[] {
         typeof item === "object" &&
         item !== null &&
         "name" in item &&
-        typeof (item as Record<string, unknown>).name === "string",
+        typeof (item as Record<string, unknown>).name === "string"
     )
   );
 }
@@ -39,7 +39,7 @@ export function TeamSection() {
             name: m.name,
             designation: m.title ?? "Software Engineer",
             image: m.picture ?? "",
-          })),
+          }))
         );
       })
       .catch((_err: unknown) => {

--- a/frontend/src/components/TeamSection.tsx
+++ b/frontend/src/components/TeamSection.tsx
@@ -9,6 +9,19 @@ interface TeamMember {
   title: string | null;
 }
 
+function isTeamMemberArray(data: unknown): data is TeamMember[] {
+  return (
+    Array.isArray(data) &&
+    data.every(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        "name" in item &&
+        typeof (item as Record<string, unknown>).name === "string",
+    )
+  );
+}
+
 export function TeamSection() {
   const [people, setPeople] = useState<
     { id: number; name: string; designation: string; image: string }[]
@@ -16,19 +29,22 @@ export function TeamSection() {
 
   useEffect(() => {
     fetch("/api/public/team")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((team: TeamMember[] | null) => {
-        if (!team || team.length === 0) return;
+      .then(async (r) => {
+        if (!r.ok) return;
+        const data: unknown = await r.json();
+        if (!isTeamMemberArray(data) || data.length === 0) return;
         setPeople(
-          team.map((m, i) => ({
+          data.map((m, i) => ({
             id: i + 1,
             name: m.name,
-            designation: m.title || "Software Engineer",
-            image: m.picture || "",
-          }))
+            designation: m.title ?? "Software Engineer",
+            image: m.picture ?? "",
+          })),
         );
       })
-      .catch(() => {});
+      .catch((_err: unknown) => {
+        // Team section is non-critical, silently fail
+      });
   }, []);
 
   if (people.length === 0) return null;


### PR DESCRIPTION
Change backend fetch in the public team API route to use cache: "no-store" to always fetch fresh data. In TeamSection, add a runtime type guard (isTeamMemberArray) and update the client fetch flow to check response.ok, parse JSON safely, validate the payload shape, and early-return on empty/invalid data. Use nullish coalescing for designation and image defaults, and add a silent catch for non-critical failures.