### PR TITLE
Simplify catch handler in TeamSection

### DIFF
--- a/frontend/src/components/TeamSection.tsx
+++ b/frontend/src/components/TeamSection.tsx
@@ -42,7 +42,7 @@ export function TeamSection() {
           })),
         );
       })
-      .catch((_err: unknown) => {
+      .catch(() => {
         // Team section is non-critical, silently fail
       });
   }, []);


### PR DESCRIPTION
Remove the unused `_err: unknown` parameter from the catch callback in TeamSection.tsx. The change keeps the existing silent-fail behavior for the non-critical team section and eliminates an unused parameter (and related typing) from the handler.