### PR TITLE
feat: increase description column length to 5000

### DIFF
--- a/backend/src/main/java/com/pm4/istp/domain/entites/Challenge.java
+++ b/backend/src/main/java/com/pm4/istp/domain/entites/Challenge.java
@@ -31,7 +31,7 @@ public class Challenge {
   @Column(name = "short_description")
   private String shortDescription;
 
-  @Column(name = "description", nullable = true)
+  @Column(name = "description", nullable = true, length = 5000)
   private String description;
 
   @Column(name = "status", nullable = false)


### PR DESCRIPTION
Extend the description field on the Challenge entity from the default VARCHAR(255) to 5000 characters to allow longer challenge descriptions.