### PR TITLE
Handle and validate oversized user/course fields

### DIFF
--- a/backend/src/main/java/com/pm4/istp/domain/entites/Course.java
+++ b/backend/src/main/java/com/pm4/istp/domain/entites/Course.java
@@ -40,7 +40,7 @@ public class Course {
   @Column(name = "is_private", nullable = false, columnDefinition = "boolean default false")
   private boolean isPrivate;
 
-  @Column(name = "image_url", nullable = true)
+  @Column(name = "image_url", nullable = true, length = 2048)
   private String imageUrl;
 
   @Column(name = "topic", nullable = true)

--- a/backend/src/main/java/com/pm4/istp/domain/entites/User.java
+++ b/backend/src/main/java/com/pm4/istp/domain/entites/User.java
@@ -22,19 +22,19 @@ public class User {
   @Column(name = "id", updatable = false, nullable = false, unique = true)
   private UUID id;
 
-  @Column(name = "name", nullable = false)
+  @Column(name = "name", nullable = false, length = 255)
   private String name;
 
-  @Column(name = "email", nullable = false, unique = true)
+  @Column(name = "email", nullable = false, unique = true, length = 255)
   private String email;
 
-  @Column(name = "username")
+  @Column(name = "username", length = 255)
   private String username;
 
-  @Column(name = "picture")
+  @Column(name = "picture", columnDefinition = "TEXT")
   private String picture;
 
-  @Column(name = "title")
+  @Column(name = "title", length = 255)
   private String title;
 
   @JsonIgnore

--- a/backend/src/main/java/com/pm4/istp/dto/CreateCourseRequestDto.java
+++ b/backend/src/main/java/com/pm4/istp/dto/CreateCourseRequestDto.java
@@ -28,7 +28,10 @@ public class CreateCourseRequestDto {
   @JsonProperty("isPrivate")
   private boolean isPrivate;
 
+  @Size(max = 2048, message = "Image URL must be at most 2048 characters")
   private String imageUrl;
+
+  @Size(max = 255, message = "Topic must be at most 255 characters")
   private String topic;
 
   @NotNull(message = "Instructor information is required")

--- a/backend/src/main/java/com/pm4/istp/dto/UpdateCourseRequestDto.java
+++ b/backend/src/main/java/com/pm4/istp/dto/UpdateCourseRequestDto.java
@@ -28,7 +28,10 @@ public class UpdateCourseRequestDto {
   @JsonProperty("isPrivate")
   private boolean isPrivate;
 
+  @Size(max = 2048, message = "Image URL must be at most 2048 characters")
   private String imageUrl;
+
+  @Size(max = 255, message = "Topic must be at most 255 characters")
   private String topic;
 
   @NotNull(message = "Instructor information is required")

--- a/backend/src/main/java/com/pm4/istp/filters/UserProvisioningFilter.java
+++ b/backend/src/main/java/com/pm4/istp/filters/UserProvisioningFilter.java
@@ -56,7 +56,8 @@ public class UserProvisioningFilter extends OncePerRequestFilter {
       Optional<User> existingUser = userRepository.findById(keycloakId);
 
       String fullName =
-          discardIfTooLong(normalize(jwt.getClaimAsString("name")), MAX_COLUMN_LENGTH, "name", keycloakId);
+          discardIfTooLong(
+              normalize(jwt.getClaimAsString("name")), MAX_COLUMN_LENGTH, "name", keycloakId);
       String givenName =
           discardIfTooLong(
               normalize(jwt.getClaimAsString("given_name")),

--- a/backend/src/main/java/com/pm4/istp/filters/UserProvisioningFilter.java
+++ b/backend/src/main/java/com/pm4/istp/filters/UserProvisioningFilter.java
@@ -33,6 +33,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class UserProvisioningFilter extends OncePerRequestFilter {
 
+  private static final int MAX_COLUMN_LENGTH = 255;
+  private static final int MAX_PICTURE_LENGTH = 2048;
+
   private final UserRepository userRepository;
 
   @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:}")
@@ -52,13 +55,38 @@ public class UserProvisioningFilter extends OncePerRequestFilter {
       UUID keycloakId = UUID.fromString(jwt.getSubject());
       Optional<User> existingUser = userRepository.findById(keycloakId);
 
-      String fullName = normalize(jwt.getClaimAsString("name"));
-      String givenName = normalize(jwt.getClaimAsString("given_name"));
-      String familyName = normalize(jwt.getClaimAsString("family_name"));
-      String username = normalize(jwt.getClaimAsString("preferred_username"));
-      String emailClaim = normalize(jwt.getClaimAsString("email"));
-      String pictureClaim = normalize(jwt.getClaimAsString("picture"));
-      String titleClaim = normalize(jwt.getClaimAsString("title"));
+      String fullName =
+          discardIfTooLong(normalize(jwt.getClaimAsString("name")), MAX_COLUMN_LENGTH, "name", keycloakId);
+      String givenName =
+          discardIfTooLong(
+              normalize(jwt.getClaimAsString("given_name")),
+              MAX_COLUMN_LENGTH,
+              "given_name",
+              keycloakId);
+      String familyName =
+          discardIfTooLong(
+              normalize(jwt.getClaimAsString("family_name")),
+              MAX_COLUMN_LENGTH,
+              "family_name",
+              keycloakId);
+      String username =
+          discardIfTooLong(
+              normalize(jwt.getClaimAsString("preferred_username")),
+              MAX_COLUMN_LENGTH,
+              "preferred_username",
+              keycloakId);
+      String emailClaim =
+          discardIfTooLong(
+              normalize(jwt.getClaimAsString("email")), MAX_COLUMN_LENGTH, "email", keycloakId);
+      String pictureClaim =
+          discardIfTooLong(
+              normalize(jwt.getClaimAsString("picture")),
+              MAX_PICTURE_LENGTH,
+              "picture",
+              keycloakId);
+      String titleClaim =
+          discardIfTooLong(
+              normalize(jwt.getClaimAsString("title")), MAX_COLUMN_LENGTH, "title", keycloakId);
       String combinedName = combineNameParts(givenName, familyName);
 
       Optional<UserInfoProfile> userInfoProfile =
@@ -76,7 +104,11 @@ public class UserProvisioningFilter extends OncePerRequestFilter {
       String email =
           firstNonBlank(
               emailClaim,
-              userInfoProfile.map(UserInfoProfile::email).orElse(null),
+              discardIfTooLong(
+                  userInfoProfile.map(UserInfoProfile::email).orElse(null),
+                  MAX_COLUMN_LENGTH,
+                  "email",
+                  keycloakId),
               existingUser.map(User::getEmail).map(this::normalize).orElse(null));
 
       if (email == null) {
@@ -87,23 +119,35 @@ public class UserProvisioningFilter extends OncePerRequestFilter {
       }
 
       String displayName =
-          resolveDisplayName(
-              fullName,
-              combinedName,
-              userInfoProfile.map(UserInfoProfile::name).orElse(null),
-              existingUser.map(User::getName).map(this::normalize).orElse(null),
-              username,
-              email,
+          discardIfTooLong(
+              resolveDisplayName(
+                  fullName,
+                  combinedName,
+                  userInfoProfile.map(UserInfoProfile::name).orElse(null),
+                  existingUser.map(User::getName).map(this::normalize).orElse(null),
+                  username,
+                  email,
+                  keycloakId),
+              MAX_COLUMN_LENGTH,
+              "displayName",
               keycloakId);
       String picture =
           firstNonBlank(
               pictureClaim,
-              userInfoProfile.map(UserInfoProfile::picture).orElse(null),
+              discardIfTooLong(
+                  userInfoProfile.map(UserInfoProfile::picture).orElse(null),
+                  MAX_PICTURE_LENGTH,
+                  "picture",
+                  keycloakId),
               existingUser.map(User::getPicture).map(this::normalize).orElse(null));
       String title =
           firstNonBlank(
               titleClaim,
-              userInfoProfile.map(UserInfoProfile::title).orElse(null),
+              discardIfTooLong(
+                  userInfoProfile.map(UserInfoProfile::title).orElse(null),
+                  MAX_COLUMN_LENGTH,
+                  "title",
+                  keycloakId),
               existingUser.map(User::getTitle).map(this::normalize).orElse(null));
 
       Set<UserRoleEnum> roles =
@@ -234,6 +278,19 @@ public class UserProvisioningFilter extends OncePerRequestFilter {
       }
     }
     return null;
+  }
+
+  private String discardIfTooLong(String value, int maxLength, String fieldName, UUID keycloakId) {
+    if (value != null && value.length() > maxLength) {
+      log.warn(
+          "Discarding {} value exceeding {} characters (length={}, userId={})",
+          fieldName,
+          maxLength,
+          value.length(),
+          keycloakId);
+      return null;
+    }
+    return value;
   }
 
   private String normalize(String value) {

--- a/backend/src/test/java/com/pm4/istp/filters/UserProvisioningFilterTest.java
+++ b/backend/src/test/java/com/pm4/istp/filters/UserProvisioningFilterTest.java
@@ -156,6 +156,154 @@ class UserProvisioningFilterTest {
     }
 
     @Test
+    void doFilterInternal_oversizedPicture_discardsPictureAndSavesUser() throws Exception {
+        String oversizedPicture = "https://example.com/" + "a".repeat(2040);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getPrincipal()).thenReturn(jwt);
+        when(jwt.getSubject()).thenReturn(USER_ID.toString());
+        doReturn(USERNAME).when(jwt).getClaimAsString("preferred_username");
+        doReturn(FULL_NAME).when(jwt).getClaimAsString("name");
+        doReturn(EMAIL).when(jwt).getClaimAsString("email");
+        doReturn(oversizedPicture).when(jwt).getClaimAsString("picture");
+        when(authentication.getAuthorities()).thenReturn(Set.of());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getPicture()).isNull();
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_longButValidPicture_savesPictureUrl() throws Exception {
+        String longValidPicture = "https://example.com/" + "a".repeat(2028);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getPrincipal()).thenReturn(jwt);
+        when(jwt.getSubject()).thenReturn(USER_ID.toString());
+        doReturn(USERNAME).when(jwt).getClaimAsString("preferred_username");
+        doReturn(FULL_NAME).when(jwt).getClaimAsString("name");
+        doReturn(EMAIL).when(jwt).getClaimAsString("email");
+        doReturn(longValidPicture).when(jwt).getClaimAsString("picture");
+        when(authentication.getAuthorities()).thenReturn(Set.of());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getPicture()).isEqualTo(longValidPicture);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_oversizedUsername_discardsUsernameAndSavesUser() throws Exception {
+        String oversizedUsername = "u".repeat(300);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getPrincipal()).thenReturn(jwt);
+        when(jwt.getSubject()).thenReturn(USER_ID.toString());
+        doReturn(oversizedUsername).when(jwt).getClaimAsString("preferred_username");
+        doReturn(FULL_NAME).when(jwt).getClaimAsString("name");
+        doReturn(EMAIL).when(jwt).getClaimAsString("email");
+        when(authentication.getAuthorities()).thenReturn(Set.of());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getUsername()).isNull();
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_oversizedName_discardsNameAndUsesFallback() throws Exception {
+        String oversizedName = "n".repeat(300);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getPrincipal()).thenReturn(jwt);
+        when(jwt.getSubject()).thenReturn(USER_ID.toString());
+        doReturn(USERNAME).when(jwt).getClaimAsString("preferred_username");
+        doReturn(oversizedName).when(jwt).getClaimAsString("name");
+        doReturn(EMAIL).when(jwt).getClaimAsString("email");
+        when(authentication.getAuthorities()).thenReturn(Set.of());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getName()).isEqualTo(USERNAME);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_oversizedTitle_discardsTitleAndSavesUser() throws Exception {
+        String oversizedTitle = "t".repeat(300);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getPrincipal()).thenReturn(jwt);
+        when(jwt.getSubject()).thenReturn(USER_ID.toString());
+        doReturn(USERNAME).when(jwt).getClaimAsString("preferred_username");
+        doReturn(FULL_NAME).when(jwt).getClaimAsString("name");
+        doReturn(EMAIL).when(jwt).getClaimAsString("email");
+        doReturn(oversizedTitle).when(jwt).getClaimAsString("title");
+        when(authentication.getAuthorities()).thenReturn(Set.of());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getTitle()).isNull();
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_oversizedEmail_withExistingUser_usesExistingEmail() throws Exception {
+        String oversizedEmail = "a".repeat(250) + "@example.com";
+        User existingUser = new User();
+        existingUser.setId(USER_ID);
+        existingUser.setName(FULL_NAME);
+        existingUser.setEmail(EMAIL);
+        existingUser.setUsername(USERNAME);
+        existingUser.setPicture(PICTURE);
+        existingUser.setRoles(Set.of());
+
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getPrincipal()).thenReturn(jwt);
+        when(jwt.getSubject()).thenReturn(USER_ID.toString());
+        doReturn(USERNAME).when(jwt).getClaimAsString("preferred_username");
+        doReturn(FULL_NAME).when(jwt).getClaimAsString("name");
+        doReturn(oversizedEmail).when(jwt).getClaimAsString("email");
+        doReturn(PICTURE).when(jwt).getClaimAsString("picture");
+        when(authentication.getAuthorities()).thenReturn(Set.of());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(existingUser));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(userRepository, never()).save(any());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_oversizedEmail_withNoExistingUser_returns400() throws Exception {
+        String oversizedEmail = "a".repeat(250) + "@example.com";
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getPrincipal()).thenReturn(jwt);
+        when(jwt.getSubject()).thenReturn(USER_ID.toString());
+        doReturn(USERNAME).when(jwt).getClaimAsString("preferred_username");
+        doReturn(FULL_NAME).when(jwt).getClaimAsString("name");
+        doReturn(oversizedEmail).when(jwt).getClaimAsString("email");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(userRepository, never()).save(any());
+        verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST, "Unable to provision user: email is required");
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
     void doFilterInternal_nullAuthentication_skipsProvisioningAndContinuesChain() throws Exception {
         when(securityContext.getAuthentication()).thenReturn(null);
 


### PR DESCRIPTION
Add length constraints and runtime guards to prevent storing oversized values. Updated entity mappings (Course.imageUrl length=2048; User name, email, username, title lengths set to 255; User.picture stored as TEXT). Added @Size validations to Create/UpdateCourseRequestDto (imageUrl max 2048, topic max 255). Implemented filtering logic in UserProvisioningFilter to discard JWT/profile claim values that exceed DB column limits (MAX_COLUMN_LENGTH=255, MAX_PICTURE_LENGTH=2048) with logging via discardIfTooLong, and updated how display name/email/picture/title are resolved accordingly. Added unit tests to verify oversized picture/username/name/title/email behaviors and proper provisioning/error handling.