### PR TITLE
Bugfix/remove admin config byte size

### DIFF
--- a/backend/src/main/java/com/pm4/istp/admin/dto/AdminConfigRequest.java
+++ b/backend/src/main/java/com/pm4/istp/admin/dto/AdminConfigRequest.java
@@ -13,8 +13,8 @@ public class AdminConfigRequest {
   private String cpuLimit;
 
   @Pattern(
-      regexp = "^\\d+(B|Mi|Gi|Ti)?$",
-      message = "Memory limit must be a number followed by optional unit (B, Mi, Gi, or Ti)")
+      regexp = "^\\d+(Mi|Gi|Ti)?$",
+      message = "Memory limit must be a number followed by optional unit (Mi, Gi, or Ti)")
   private String memoryLimit;
 
   private String kubeconfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4794,6 +4794,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/src/features/admin/components/AdminConfigForm.tsx
+++ b/frontend/src/features/admin/components/AdminConfigForm.tsx
@@ -38,7 +38,7 @@ export default function AdminConfigForm({ initialConfig }: Props) {
 
   const config: AdminConfigResponse = initialConfig;
 
-  const defaultMemoryUnit = MemoryUnit.Byte;
+  const defaultMemoryUnit = MemoryUnit.MebiByte;
 
   const getInitialFormValues = (adminConfig: AdminConfigResponse) => {
     try {

--- a/frontend/src/shared/lib/memoryUnit.ts
+++ b/frontend/src/shared/lib/memoryUnit.ts
@@ -1,5 +1,4 @@
 export const enum MemoryUnit {
-  Byte = "B",
   MebiByte = "Mi",
   GibiByte = "Gi",
   TebiByte = "Ti",
@@ -11,7 +10,6 @@ export type MemorySpecification = {
 };
 
 export const memoryUnits: ReadonlyArray<MemoryUnit> = [
-  MemoryUnit.Byte,
   MemoryUnit.MebiByte,
   MemoryUnit.GibiByte,
   MemoryUnit.TebiByte,
@@ -22,7 +20,7 @@ export const memorySpecificationToString = (memorySpecification: MemorySpecifica
 };
 
 export const stringToMemorySpecification = (specificationAsString: string): MemorySpecification => {
-  const match = specificationAsString.match(/^(\d+)(B|Mi|Gi|Ti)$/);
+  const match = specificationAsString.match(/^(\d+)(Mi|Gi|Ti)$/);
   if (!match) {
     throw new Error(specificationAsString + " is not a valid memory specification.");
   }


### PR DESCRIPTION
remove the selection for size of Bytes for memory in the admin config because kubernetes does not know this type of size for memory allocation.