### PR TITLE
feat: add challenge play view with sub-task flag submission

### DIFF
--- a/backend/src/main/java/com/pm4/istp/course/controllers/ChallengeController.java
+++ b/backend/src/main/java/com/pm4/istp/course/controllers/ChallengeController.java
@@ -7,9 +7,12 @@ import com.pm4.istp.course.db.UpdateChallengeRequest;
 import com.pm4.istp.course.db.entities.Challenge;
 import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
 import com.pm4.istp.course.dto.ChallengeDetailResponseDto;
+import com.pm4.istp.course.dto.ChallengeStudentDto;
 import com.pm4.istp.course.dto.CreateChallengeRequestDto;
 import com.pm4.istp.course.dto.CreateChallengeResponseDto;
 import com.pm4.istp.course.dto.ListChallengeResponseDto;
+import com.pm4.istp.course.dto.SubTaskSubmissionRequestDto;
+import com.pm4.istp.course.dto.SubTaskSubmissionResponseDto;
 import com.pm4.istp.course.dto.UpdateChallengeRequestDto;
 import com.pm4.istp.course.dto.VisibilityImpactResponseDto;
 import com.pm4.istp.course.mappers.ChallengeMapper;
@@ -232,5 +235,78 @@ public class ChallengeController {
     UUID userId = parseUserId(jwt);
     int affectedCourseCount = challengeService.previewVisibilityImpact(userId, id, status);
     return ResponseEntity.ok(new VisibilityImpactResponseDto(affectedCourseCount));
+  }
+
+  @Operation(
+      summary = "Get a challenge in student play view",
+      description =
+          "Returns a challenge formatted for students (no sub-task flags, with per-user solved"
+              + " progress). Caller must be enrolled in the given course, and the challenge must"
+              + " belong to it.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Challenge retrieved successfully",
+            content = @Content(schema = @Schema(implementation = ChallengeStudentDto.class))),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Access denied",
+            content = @Content(schema = @Schema(implementation = ErrorDto.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Challenge not found",
+            content = @Content(schema = @Schema(implementation = ErrorDto.class)))
+      })
+  @GetMapping("/{id}/play")
+  public ResponseEntity<ChallengeStudentDto> getChallengeForPlay(
+      @AuthenticationPrincipal Jwt jwt,
+      @PathVariable UUID id,
+      @RequestParam("courseId") UUID courseId) {
+    UUID userId = parseUserId(jwt);
+    ChallengeStudentDto dto = challengeService.getChallengeForPlay(userId, courseId, id);
+    return ResponseEntity.ok(dto);
+  }
+
+  @Operation(
+      summary = "Submit a flag for a sub-task",
+      description =
+          "Validates the submitted flag against the stored plaintext flag (case-sensitive). On a"
+              + " correct submission the sub-task is marked as solved for the authenticated user."
+              + " Already-solved sub-tasks cannot be re-submitted.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Submission processed",
+            content =
+                @Content(schema = @Schema(implementation = SubTaskSubmissionResponseDto.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid flag format",
+            content = @Content(schema = @Schema(implementation = ErrorDto.class))),
+        @ApiResponse(
+            responseCode = "403",
+            description = "User not enrolled in a course containing this challenge",
+            content = @Content(schema = @Schema(implementation = ErrorDto.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Challenge or sub-task not found",
+            content = @Content(schema = @Schema(implementation = ErrorDto.class))),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Sub-task already solved",
+            content = @Content(schema = @Schema(implementation = ErrorDto.class)))
+      })
+  @PostMapping("/{challengeId}/subtasks/{subTaskId}/submit")
+  public ResponseEntity<SubTaskSubmissionResponseDto> submitSubTaskFlag(
+      @AuthenticationPrincipal Jwt jwt,
+      @PathVariable UUID challengeId,
+      @PathVariable UUID subTaskId,
+      @Valid @RequestBody SubTaskSubmissionRequestDto request) {
+    UUID userId = parseUserId(jwt);
+    SubTaskSubmissionResponseDto response =
+        challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, request.getFlag());
+    return ResponseEntity.ok(response);
   }
 }

--- a/backend/src/main/java/com/pm4/istp/course/controllers/CourseController.java
+++ b/backend/src/main/java/com/pm4/istp/course/controllers/CourseController.java
@@ -7,7 +7,7 @@ import com.pm4.istp.course.db.UpdateCourseRequest;
 import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
 import com.pm4.istp.course.db.entities.Course;
 import com.pm4.istp.course.db.entities.CourseEnrollment;
-import com.pm4.istp.course.dto.ChallengeDetailResponseDto;
+import com.pm4.istp.course.dto.ChallengeStudentDto;
 import com.pm4.istp.course.dto.CourseDetailInstructorResponseDto;
 import com.pm4.istp.course.dto.CourseDetailResponseDto;
 import com.pm4.istp.course.dto.CourseParticipantResponseDto;
@@ -16,10 +16,13 @@ import com.pm4.istp.course.dto.CreateCourseResponseDto;
 import com.pm4.istp.course.dto.JoinByInviteCodeRequestDto;
 import com.pm4.istp.course.dto.ListCourseResponseDto;
 import com.pm4.istp.course.dto.PublicCourseDetailResponseDto;
+import com.pm4.istp.course.dto.SubTaskStudentDto;
 import com.pm4.istp.course.dto.UpdateCourseChallengesRequestDto;
 import com.pm4.istp.course.dto.UpdateCourseRequestDto;
 import com.pm4.istp.course.mappers.CourseMapper;
 import com.pm4.istp.course.repositories.CourseEnrollmentRepository;
+import com.pm4.istp.course.repositories.SubTaskCompletionRepository;
+import com.pm4.istp.course.repositories.SubTaskRepository;
 import com.pm4.istp.course.services.CourseService;
 import com.pm4.istp.course.services.CourseTopicService;
 import com.pm4.istp.shared.dto.ErrorDto;
@@ -31,7 +34,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -59,6 +66,8 @@ public class CourseController {
   private final CourseService courseService;
   private final CourseEnrollmentRepository courseEnrollmentRepository;
   private final CourseTopicService courseTopicService;
+  private final SubTaskCompletionRepository subTaskCompletionRepository;
+  private final SubTaskRepository subTaskRepository;
 
   @Operation(
       summary = "Create a course",
@@ -460,18 +469,78 @@ public class CourseController {
     filterOutDraftChallenges(dto);
     setInstructorIdsToNull(dto.getCourseInstructors());
     setChallengeCreatorIdsToNull(dto.getCourseChallenges());
+    populateStudentProgress(dto.getCourseChallenges(), userId);
     dto.setInviteCode(null);
     return dto;
   }
 
   private void filterOutDraftChallenges(PublicCourseDetailResponseDto dto) {
-    List<ChallengeDetailResponseDto> challenges = new ArrayList<>();
-    for (ChallengeDetailResponseDto challenge : dto.getCourseChallenges()) {
+    List<ChallengeStudentDto> challenges = new ArrayList<>();
+    for (ChallengeStudentDto challenge : dto.getCourseChallenges()) {
       if (challenge.getStatus() != ChallengeStatusEnum.DRAFT) {
         challenges.add(challenge);
       }
     }
     dto.setCourseChallenges(List.copyOf(challenges));
+  }
+
+  /**
+   * Fills in per-student progress on each challenge and its sub-tasks. Reads SubTaskCompletion rows
+   * in a single query for all sub-tasks of all visible challenges, then marks matching sub-tasks as
+   * solved.
+   */
+  private void populateStudentProgress(List<ChallengeStudentDto> challenges, UUID userId) {
+    if (challenges == null || challenges.isEmpty()) {
+      return;
+    }
+    List<UUID> subTaskIds = new ArrayList<>();
+    for (ChallengeStudentDto challenge : challenges) {
+      List<SubTaskStudentDto> subTasks = challenge.getSubTasks();
+      if (subTasks == null) {
+        continue;
+      }
+      for (SubTaskStudentDto st : subTasks) {
+        subTaskIds.add(st.getId());
+      }
+    }
+    Set<UUID> solvedIds =
+        subTaskIds.isEmpty()
+            ? Set.of()
+            : new HashSet<>(subTaskCompletionRepository.findSolvedSubTaskIds(userId, subTaskIds));
+
+    Map<UUID, String> flagsBySolvedId = loadFlagsForSolved(solvedIds);
+
+    for (ChallengeStudentDto challenge : challenges) {
+      List<SubTaskStudentDto> subTasks =
+          challenge.getSubTasks() == null ? List.of() : challenge.getSubTasks();
+      int solvedCount = 0;
+      for (SubTaskStudentDto st : subTasks) {
+        boolean solved = solvedIds.contains(st.getId());
+        st.setSolved(solved);
+        if (solved) {
+          st.setSolvedFlag(flagsBySolvedId.get(st.getId()));
+          solvedCount++;
+        }
+      }
+      challenge.setTotalSubTaskCount(subTasks.size());
+      challenge.setSolvedSubTaskCount(solvedCount);
+      challenge.setSolved(!subTasks.isEmpty() && solvedCount == subTasks.size());
+    }
+  }
+
+  /**
+   * Returns a {@code subTaskId → flag} map for the given solved sub-task ids. Empty map for an
+   * empty input — exposed only for the user's own solved sub-tasks, never to anyone else.
+   */
+  private Map<UUID, String> loadFlagsForSolved(Set<UUID> solvedIds) {
+    if (solvedIds.isEmpty()) {
+      return Map.of();
+    }
+    Map<UUID, String> flagsBySolvedId = new HashMap<>();
+    for (Object[] row : subTaskRepository.findFlagsByIds(solvedIds)) {
+      flagsBySolvedId.put((UUID) row[0], (String) row[1]);
+    }
+    return flagsBySolvedId;
   }
 
   private void setInstructorIdsToNull(List<CourseDetailInstructorResponseDto> courseInstructors) {
@@ -481,9 +550,11 @@ public class CourseController {
     }
   }
 
-  private void setChallengeCreatorIdsToNull(List<ChallengeDetailResponseDto> courseChallenges) {
-    for (ChallengeDetailResponseDto challengeDetailResponseDto : courseChallenges) {
-      challengeDetailResponseDto.getCreator().setId(null);
+  private void setChallengeCreatorIdsToNull(List<ChallengeStudentDto> courseChallenges) {
+    for (ChallengeStudentDto challenge : courseChallenges) {
+      if (challenge.getCreator() != null) {
+        challenge.getCreator().setId(null);
+      }
     }
   }
 }

--- a/backend/src/main/java/com/pm4/istp/course/db/entities/SubTaskCompletion.java
+++ b/backend/src/main/java/com/pm4/istp/course/db/entities/SubTaskCompletion.java
@@ -1,0 +1,46 @@
+package com.pm4.istp.course.db.entities;
+
+import com.pm4.istp.user.db.entities.User;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+    name = "sub_task_completions",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uk_sub_task_completion_user_sub_task",
+            columnNames = {"user_id", "sub_task_id"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubTaskCompletion {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "id", updatable = false, nullable = false, unique = true)
+  private UUID id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "sub_task_id", nullable = false)
+  private SubTask subTask;
+
+  @Column(name = "solved_at", nullable = false, updatable = false)
+  private LocalDateTime solvedAt;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/pm4/istp/course/dto/ChallengeStudentDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/ChallengeStudentDto.java
@@ -1,0 +1,39 @@
+package com.pm4.istp.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pm4.istp.course.db.entities.ChallengeDifficultyEnum;
+import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Student-facing challenge DTO — used both on the public course detail page and on the play view.
+ * Carries no sub-task flags; instead includes per-student progress ({@code solvedSubTaskCount},
+ * {@code totalSubTaskCount}, {@code solved}).
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChallengeStudentDto {
+  private UUID id;
+  private String title;
+  private String shortDescription;
+  private String description;
+  private ChallengeStatusEnum status;
+  private ChallengeDifficultyEnum difficulty;
+  private int maxScore;
+  private ChallengeCreatorResponseDto creator;
+  private List<SubTaskStudentDto> subTasks;
+  private int solvedSubTaskCount;
+  private int totalSubTaskCount;
+
+  @JsonProperty("isSolved")
+  private boolean solved;
+
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/pm4/istp/course/dto/PublicCourseDetailResponseDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/PublicCourseDetailResponseDto.java
@@ -31,7 +31,7 @@ public class PublicCourseDetailResponseDto {
 
   private List<CourseDetailInstructorResponseDto> courseInstructors;
   private List<CourseParticipantResponseDto> participants;
-  private List<ChallengeDetailResponseDto> courseChallenges;
+  private List<ChallengeStudentDto> courseChallenges;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/pm4/istp/course/dto/SubTaskStudentDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/SubTaskStudentDto.java
@@ -1,0 +1,31 @@
+package com.pm4.istp.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Student-facing sub-task DTO. Intentionally omits the {@code flag} field so it never leaks to
+ * non-creator callers.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubTaskStudentDto {
+  private UUID id;
+  private String title;
+  private String description;
+  private int orderIndex;
+
+  @JsonProperty("isSolved")
+  private boolean solved;
+
+  /**
+   * The plaintext flag. Populated only when the requesting user has solved this sub-task; {@code
+   * null} otherwise. Returning it back to the solver lets the frontend re-display what they
+   * originally submitted.
+   */
+  private String solvedFlag;
+}

--- a/backend/src/main/java/com/pm4/istp/course/dto/SubTaskSubmissionRequestDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/SubTaskSubmissionRequestDto.java
@@ -1,0 +1,16 @@
+package com.pm4.istp.course.dto;
+
+import com.pm4.istp.shared.validation.ValidFlag;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubTaskSubmissionRequestDto {
+  @NotBlank(message = "Flag must not be blank")
+  @ValidFlag
+  private String flag;
+}

--- a/backend/src/main/java/com/pm4/istp/course/dto/SubTaskSubmissionResponseDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/SubTaskSubmissionResponseDto.java
@@ -1,0 +1,20 @@
+package com.pm4.istp.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubTaskSubmissionResponseDto {
+  @JsonProperty("isCorrect")
+  private boolean correct;
+
+  @JsonProperty("isChallengeSolved")
+  private boolean challengeSolved;
+
+  private int solvedSubTaskCount;
+  private int totalSubTaskCount;
+}

--- a/backend/src/main/java/com/pm4/istp/course/exceptions/SubTaskAlreadySolvedException.java
+++ b/backend/src/main/java/com/pm4/istp/course/exceptions/SubTaskAlreadySolvedException.java
@@ -1,0 +1,25 @@
+package com.pm4.istp.course.exceptions;
+
+import com.pm4.istp.shared.IstpException;
+
+public class SubTaskAlreadySolvedException extends IstpException {
+
+  public SubTaskAlreadySolvedException() {}
+
+  public SubTaskAlreadySolvedException(String message) {
+    super(message);
+  }
+
+  public SubTaskAlreadySolvedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public SubTaskAlreadySolvedException(Throwable cause) {
+    super(cause);
+  }
+
+  public SubTaskAlreadySolvedException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+}

--- a/backend/src/main/java/com/pm4/istp/course/exceptions/SubTaskNotFoundException.java
+++ b/backend/src/main/java/com/pm4/istp/course/exceptions/SubTaskNotFoundException.java
@@ -1,0 +1,25 @@
+package com.pm4.istp.course.exceptions;
+
+import com.pm4.istp.shared.IstpException;
+
+public class SubTaskNotFoundException extends IstpException {
+
+  public SubTaskNotFoundException() {}
+
+  public SubTaskNotFoundException(String message) {
+    super(message);
+  }
+
+  public SubTaskNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public SubTaskNotFoundException(Throwable cause) {
+    super(cause);
+  }
+
+  public SubTaskNotFoundException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+}

--- a/backend/src/main/java/com/pm4/istp/course/mappers/ChallengeMapper.java
+++ b/backend/src/main/java/com/pm4/istp/course/mappers/ChallengeMapper.java
@@ -8,11 +8,13 @@ import com.pm4.istp.course.db.entities.CourseChallenge;
 import com.pm4.istp.course.db.entities.SubTask;
 import com.pm4.istp.course.dto.ChallengeCreatorResponseDto;
 import com.pm4.istp.course.dto.ChallengeDetailResponseDto;
+import com.pm4.istp.course.dto.ChallengeStudentDto;
 import com.pm4.istp.course.dto.CourseChallengeResponseDto;
 import com.pm4.istp.course.dto.CreateChallengeRequestDto;
 import com.pm4.istp.course.dto.CreateChallengeResponseDto;
 import com.pm4.istp.course.dto.SubTaskRequestDto;
 import com.pm4.istp.course.dto.SubTaskResponseDto;
+import com.pm4.istp.course.dto.SubTaskStudentDto;
 import com.pm4.istp.course.dto.UpdateChallengeRequestDto;
 import com.pm4.istp.user.db.entities.User;
 import org.mapstruct.Mapper;
@@ -36,6 +38,16 @@ public interface ChallengeMapper {
   ChallengeCreatorResponseDto toCreatorDto(User user);
 
   SubTaskResponseDto toSubTaskResponseDto(SubTask subTask);
+
+  @Mapping(target = "solved", ignore = true)
+  @Mapping(target = "solvedFlag", ignore = true)
+  SubTaskStudentDto toSubTaskStudentDto(SubTask subTask);
+
+  @Mapping(target = "subTasks", source = "subTasks")
+  @Mapping(target = "solved", ignore = true)
+  @Mapping(target = "solvedSubTaskCount", ignore = true)
+  @Mapping(target = "totalSubTaskCount", ignore = true)
+  ChallengeStudentDto toStudentDto(Challenge challenge);
 
   @Mapping(target = "challengeId", source = "challenge.id")
   @Mapping(target = "challengeTitle", source = "challenge.title")

--- a/backend/src/main/java/com/pm4/istp/course/mappers/CourseMapper.java
+++ b/backend/src/main/java/com/pm4/istp/course/mappers/CourseMapper.java
@@ -8,6 +8,7 @@ import com.pm4.istp.course.db.entities.Course;
 import com.pm4.istp.course.db.entities.CourseChallenge;
 import com.pm4.istp.course.db.entities.CourseInstructor;
 import com.pm4.istp.course.dto.ChallengeDetailResponseDto;
+import com.pm4.istp.course.dto.ChallengeStudentDto;
 import com.pm4.istp.course.dto.CourseDetailResponseDto;
 import com.pm4.istp.course.dto.CreateCourseInstructorRequestDto;
 import com.pm4.istp.course.dto.CreateCourseRequestDto;
@@ -44,6 +45,12 @@ public interface CourseMapper {
 
   @Mapping(target = ".", source = "challenge")
   ChallengeDetailResponseDto toChallengeDetailResponseDto(CourseChallenge courseChallenge);
+
+  @Mapping(target = ".", source = "challenge")
+  @Mapping(target = "solved", ignore = true)
+  @Mapping(target = "solvedSubTaskCount", ignore = true)
+  @Mapping(target = "totalSubTaskCount", ignore = true)
+  ChallengeStudentDto toChallengeStudentDto(CourseChallenge courseChallenge);
 
   @Mapping(
       target = "instructorCount",

--- a/backend/src/main/java/com/pm4/istp/course/repositories/SubTaskCompletionRepository.java
+++ b/backend/src/main/java/com/pm4/istp/course/repositories/SubTaskCompletionRepository.java
@@ -1,0 +1,34 @@
+package com.pm4.istp.course.repositories;
+
+import com.pm4.istp.course.db.entities.SubTaskCompletion;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubTaskCompletionRepository extends JpaRepository<SubTaskCompletion, UUID> {
+
+  boolean existsByUserIdAndSubTaskId(UUID userId, UUID subTaskId);
+
+  @Query(
+      """
+      select c.subTask.id
+      from SubTaskCompletion c
+      where c.user.id = :userId and c.subTask.id in :subTaskIds
+      """)
+  List<UUID> findSolvedSubTaskIds(
+      @Param("userId") UUID userId, @Param("subTaskIds") Collection<UUID> subTaskIds);
+
+  @Query(
+      """
+      select c.subTask.id
+      from SubTaskCompletion c
+      where c.user.id = :userId and c.subTask.challenge.id in :challengeIds
+      """)
+  List<UUID> findSolvedSubTaskIdsForChallenges(
+      @Param("userId") UUID userId, @Param("challengeIds") Collection<UUID> challengeIds);
+}

--- a/backend/src/main/java/com/pm4/istp/course/repositories/SubTaskRepository.java
+++ b/backend/src/main/java/com/pm4/istp/course/repositories/SubTaskRepository.java
@@ -1,12 +1,18 @@
 package com.pm4.istp.course.repositories;
 
 import com.pm4.istp.course.db.entities.SubTask;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SubTaskRepository extends JpaRepository<SubTask, UUID> {
   List<SubTask> findByChallengeIdOrderByOrderIndexAsc(UUID challengeId);
+
+  @Query("select s.id, s.flag from SubTask s where s.id in :ids")
+  List<Object[]> findFlagsByIds(@Param("ids") Collection<UUID> ids);
 }

--- a/backend/src/main/java/com/pm4/istp/course/services/ChallengeService.java
+++ b/backend/src/main/java/com/pm4/istp/course/services/ChallengeService.java
@@ -4,7 +4,9 @@ import com.pm4.istp.course.db.CreateChallengeRequest;
 import com.pm4.istp.course.db.UpdateChallengeRequest;
 import com.pm4.istp.course.db.entities.Challenge;
 import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
+import com.pm4.istp.course.dto.ChallengeStudentDto;
 import com.pm4.istp.course.dto.ListChallengeResponseDto;
+import com.pm4.istp.course.dto.SubTaskSubmissionResponseDto;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,4 +26,17 @@ public interface ChallengeService {
       UUID userId, String search, Pageable pageable);
 
   int previewVisibilityImpact(UUID userId, UUID challengeId, ChallengeStatusEnum newStatus);
+
+  /**
+   * Returns the challenge in its student-facing form (no flags; with per-student progress). The
+   * caller must be enrolled in a course that contains this challenge.
+   */
+  ChallengeStudentDto getChallengeForPlay(UUID userId, UUID courseId, UUID challengeId);
+
+  /**
+   * Submits a flag for a sub-task. Case-sensitive comparison against the plaintext flag. On a
+   * correct submission the completion is persisted and cannot be re-submitted.
+   */
+  SubTaskSubmissionResponseDto submitSubTaskFlag(
+      UUID userId, UUID challengeId, UUID subTaskId, String flag);
 }

--- a/backend/src/main/java/com/pm4/istp/course/services/impl/ChallengeServiceImpl.java
+++ b/backend/src/main/java/com/pm4/istp/course/services/impl/ChallengeServiceImpl.java
@@ -6,19 +6,32 @@ import com.pm4.istp.course.db.UpdateChallengeRequest;
 import com.pm4.istp.course.db.entities.Challenge;
 import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
 import com.pm4.istp.course.db.entities.SubTask;
+import com.pm4.istp.course.db.entities.SubTaskCompletion;
+import com.pm4.istp.course.dto.ChallengeStudentDto;
 import com.pm4.istp.course.dto.ListChallengeResponseDto;
+import com.pm4.istp.course.dto.SubTaskStudentDto;
+import com.pm4.istp.course.dto.SubTaskSubmissionResponseDto;
 import com.pm4.istp.course.exceptions.ChallengeAccessDeniedException;
 import com.pm4.istp.course.exceptions.ChallengeNotFoundException;
+import com.pm4.istp.course.exceptions.SubTaskAlreadySolvedException;
+import com.pm4.istp.course.exceptions.SubTaskNotFoundException;
+import com.pm4.istp.course.mappers.ChallengeMapper;
 import com.pm4.istp.course.repositories.ChallengeRepository;
 import com.pm4.istp.course.repositories.CourseChallengeRepository;
+import com.pm4.istp.course.repositories.CourseEnrollmentRepository;
+import com.pm4.istp.course.repositories.SubTaskCompletionRepository;
+import com.pm4.istp.course.repositories.SubTaskRepository;
 import com.pm4.istp.course.services.ChallengeService;
 import com.pm4.istp.user.db.entities.User;
 import com.pm4.istp.user.exceptions.UserNotFoundException;
 import com.pm4.istp.user.repositories.UserRepository;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -32,10 +45,15 @@ public class ChallengeServiceImpl implements ChallengeService {
 
   private static final String USER_NOT_FOUND_MSG = "User with ID '%s' not found";
   private static final String CHALLENGE_NOT_FOUND_MSG = "Challenge with ID '%s' not found";
+  private static final String SUB_TASK_NOT_FOUND_MSG = "Sub-task with ID '%s' not found";
 
   private final UserRepository userRepository;
   private final ChallengeRepository challengeRepository;
   private final CourseChallengeRepository courseChallengeRepository;
+  private final SubTaskRepository subTaskRepository;
+  private final SubTaskCompletionRepository subTaskCompletionRepository;
+  private final CourseEnrollmentRepository courseEnrollmentRepository;
+  private final ChallengeMapper challengeMapper;
 
   @Override
   @Transactional
@@ -279,5 +297,138 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
     // PUBLIC: anyone can see
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public ChallengeStudentDto getChallengeForPlay(UUID userId, UUID courseId, UUID challengeId) {
+    verifyEnrollment(userId, courseId);
+
+    Challenge challenge =
+        challengeRepository
+            .findById(challengeId)
+            .orElseThrow(
+                () ->
+                    new ChallengeNotFoundException(
+                        String.format(CHALLENGE_NOT_FOUND_MSG, challengeId)));
+
+    boolean challengeBelongsToCourse =
+        courseChallengeRepository.existsByChallengeIdAndCourseInstructorId(challengeId, userId)
+            || challenge.getCourseChallenges().stream()
+                .anyMatch(cc -> cc.getCourse().getId().equals(courseId));
+    if (!challengeBelongsToCourse) {
+      throw new ChallengeAccessDeniedException(
+          String.format("Challenge '%s' is not part of course '%s'", challengeId, courseId));
+    }
+
+    ChallengeStudentDto dto = challengeMapper.toStudentDto(challenge);
+    populateStudentProgress(dto, userId, challenge);
+    return dto;
+  }
+
+  @Override
+  @Transactional
+  public SubTaskSubmissionResponseDto submitSubTaskFlag(
+      UUID userId, UUID challengeId, UUID subTaskId, String flag) {
+    User user =
+        userRepository
+            .findByIdAndDeletedAtIsNull(userId)
+            .orElseThrow(
+                () -> new UserNotFoundException(String.format(USER_NOT_FOUND_MSG, userId)));
+
+    SubTask subTask =
+        subTaskRepository
+            .findById(subTaskId)
+            .orElseThrow(
+                () ->
+                    new SubTaskNotFoundException(String.format(SUB_TASK_NOT_FOUND_MSG, subTaskId)));
+
+    if (!subTask.getChallenge().getId().equals(challengeId)) {
+      throw new SubTaskNotFoundException(
+          String.format("Sub-task '%s' does not belong to challenge '%s'", subTaskId, challengeId));
+    }
+
+    verifyEnrolledInChallengeCourse(userId, subTask.getChallenge());
+
+    if (subTaskCompletionRepository.existsByUserIdAndSubTaskId(userId, subTaskId)) {
+      throw new SubTaskAlreadySolvedException(
+          String.format("Sub-task '%s' already solved by user '%s'", subTaskId, userId));
+    }
+
+    boolean correct = subTask.getFlag() != null && subTask.getFlag().equals(flag);
+    if (correct) {
+      SubTaskCompletion completion = new SubTaskCompletion();
+      completion.setUser(user);
+      completion.setSubTask(subTask);
+      completion.setSolvedAt(LocalDateTime.now());
+      subTaskCompletionRepository.save(completion);
+    }
+
+    List<SubTask> siblings = subTask.getChallenge().getSubTasks();
+    List<UUID> siblingIds = new ArrayList<>();
+    for (SubTask s : siblings) {
+      siblingIds.add(s.getId());
+    }
+    Set<UUID> solvedIds =
+        siblingIds.isEmpty()
+            ? Set.of()
+            : new HashSet<>(subTaskCompletionRepository.findSolvedSubTaskIds(userId, siblingIds));
+    int solvedCount = solvedIds.size();
+    int totalCount = siblings.size();
+    boolean challengeSolved = totalCount > 0 && solvedCount == totalCount;
+
+    return new SubTaskSubmissionResponseDto(correct, challengeSolved, solvedCount, totalCount);
+  }
+
+  private void verifyEnrollment(UUID userId, UUID courseId) {
+    if (!courseEnrollmentRepository.existsByCourseIdAndParticipantId(courseId, userId)) {
+      throw new ChallengeAccessDeniedException(
+          String.format("User '%s' is not enrolled in course '%s'", userId, courseId));
+    }
+  }
+
+  private void verifyEnrolledInChallengeCourse(UUID userId, Challenge challenge) {
+    boolean enrolled =
+        challenge.getCourseChallenges().stream()
+            .anyMatch(
+                cc ->
+                    courseEnrollmentRepository.existsByCourseIdAndParticipantId(
+                        cc.getCourse().getId(), userId));
+    if (!enrolled) {
+      throw new ChallengeAccessDeniedException(
+          String.format(
+              "User '%s' is not enrolled in any course containing challenge '%s'",
+              userId, challenge.getId()));
+    }
+  }
+
+  private void populateStudentProgress(ChallengeStudentDto dto, UUID userId, Challenge entity) {
+    List<SubTaskStudentDto> subTasks = dto.getSubTasks() == null ? List.of() : dto.getSubTasks();
+    List<UUID> subTaskIds = new ArrayList<>();
+    for (SubTaskStudentDto st : subTasks) {
+      subTaskIds.add(st.getId());
+    }
+    Set<UUID> solvedIds =
+        subTaskIds.isEmpty()
+            ? Set.of()
+            : new HashSet<>(subTaskCompletionRepository.findSolvedSubTaskIds(userId, subTaskIds));
+
+    Map<UUID, String> flagsById = new HashMap<>();
+    for (SubTask st : entity.getSubTasks()) {
+      flagsById.put(st.getId(), st.getFlag());
+    }
+
+    int solvedCount = 0;
+    for (SubTaskStudentDto st : subTasks) {
+      boolean solved = solvedIds.contains(st.getId());
+      st.setSolved(solved);
+      if (solved) {
+        st.setSolvedFlag(flagsById.get(st.getId()));
+        solvedCount++;
+      }
+    }
+    dto.setTotalSubTaskCount(subTasks.size());
+    dto.setSolvedSubTaskCount(solvedCount);
+    dto.setSolved(!subTasks.isEmpty() && solvedCount == subTasks.size());
   }
 }

--- a/backend/src/main/java/com/pm4/istp/course/services/impl/ChallengeServiceImpl.java
+++ b/backend/src/main/java/com/pm4/istp/course/services/impl/ChallengeServiceImpl.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -313,9 +314,8 @@ public class ChallengeServiceImpl implements ChallengeService {
                         String.format(CHALLENGE_NOT_FOUND_MSG, challengeId)));
 
     boolean challengeBelongsToCourse =
-        courseChallengeRepository.existsByChallengeIdAndCourseInstructorId(challengeId, userId)
-            || challenge.getCourseChallenges().stream()
-                .anyMatch(cc -> cc.getCourse().getId().equals(courseId));
+        challenge.getCourseChallenges().stream()
+            .anyMatch(cc -> cc.getCourse().getId().equals(courseId));
     if (!challengeBelongsToCourse) {
       throw new ChallengeAccessDeniedException(
           String.format("Challenge '%s' is not part of course '%s'", challengeId, courseId));
@@ -361,7 +361,15 @@ public class ChallengeServiceImpl implements ChallengeService {
       completion.setUser(user);
       completion.setSubTask(subTask);
       completion.setSolvedAt(LocalDateTime.now());
-      subTaskCompletionRepository.save(completion);
+      try {
+        subTaskCompletionRepository.saveAndFlush(completion);
+      } catch (DataIntegrityViolationException ex) {
+        // Concurrent submission slipped past the existsByUserIdAndSubTaskId check
+        // and tripped the unique (user, sub_task) constraint. Surface as 409
+        // instead of a 500.
+        throw new SubTaskAlreadySolvedException(
+            String.format("Sub-task '%s' already solved by user '%s'", subTaskId, userId), ex);
+      }
     }
 
     List<SubTask> siblings = subTask.getChallenge().getSubTasks();
@@ -389,11 +397,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
   private void verifyEnrolledInChallengeCourse(UUID userId, Challenge challenge) {
     boolean enrolled =
-        challenge.getCourseChallenges().stream()
-            .anyMatch(
-                cc ->
-                    courseEnrollmentRepository.existsByCourseIdAndParticipantId(
-                        cc.getCourse().getId(), userId));
+        courseChallengeRepository.existsByChallengeIdAndEnrolledUserId(challenge.getId(), userId);
     if (!enrolled) {
       throw new ChallengeAccessDeniedException(
           String.format(

--- a/backend/src/main/java/com/pm4/istp/shared/util/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/pm4/istp/shared/util/GlobalExceptionHandler.java
@@ -10,6 +10,8 @@ import com.pm4.istp.course.exceptions.InvalidCourseCollaboratorException;
 import com.pm4.istp.course.exceptions.InvalidCourseShortDescriptionException;
 import com.pm4.istp.course.exceptions.InvalidInviteCodeException;
 import com.pm4.istp.course.exceptions.InviteCodeGenerationException;
+import com.pm4.istp.course.exceptions.SubTaskAlreadySolvedException;
+import com.pm4.istp.course.exceptions.SubTaskNotFoundException;
 import com.pm4.istp.shared.dto.ErrorDto;
 import com.pm4.istp.user.exceptions.UserNotFoundException;
 import jakarta.validation.ConstraintViolationException;
@@ -111,6 +113,23 @@ public class GlobalExceptionHandler {
     ErrorDto errorDto = new ErrorDto();
     errorDto.setError(ex.getMessage());
     return new ResponseEntity<>(errorDto, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(SubTaskNotFoundException.class)
+  public ResponseEntity<ErrorDto> handleSubTaskNotFoundException(SubTaskNotFoundException ex) {
+    log.error("Caught SubTaskNotFoundException", ex);
+    ErrorDto errorDto = new ErrorDto();
+    errorDto.setError("Sub-task not found");
+    return new ResponseEntity<>(errorDto, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(SubTaskAlreadySolvedException.class)
+  public ResponseEntity<ErrorDto> handleSubTaskAlreadySolvedException(
+      SubTaskAlreadySolvedException ex) {
+    log.warn("Caught SubTaskAlreadySolvedException: {}", ex.getMessage());
+    ErrorDto errorDto = new ErrorDto();
+    errorDto.setError("Sub-task already solved");
+    return new ResponseEntity<>(errorDto, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(InviteCodeGenerationException.class)

--- a/backend/src/test/java/com/pm4/istp/course/ChallengeControllerTest.java
+++ b/backend/src/test/java/com/pm4/istp/course/ChallengeControllerTest.java
@@ -16,13 +16,18 @@ import com.pm4.istp.course.db.entities.ChallengeDifficultyEnum;
 import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
 import com.pm4.istp.course.db.entities.CourseChallenge;
 import com.pm4.istp.course.dto.ChallengeDetailResponseDto;
+import com.pm4.istp.course.dto.ChallengeStudentDto;
 import com.pm4.istp.course.dto.CreateChallengeRequestDto;
 import com.pm4.istp.course.dto.CreateChallengeResponseDto;
 import com.pm4.istp.course.dto.ListChallengeResponseDto;
+import com.pm4.istp.course.dto.SubTaskSubmissionRequestDto;
+import com.pm4.istp.course.dto.SubTaskSubmissionResponseDto;
 import com.pm4.istp.course.dto.UpdateChallengeRequestDto;
 import com.pm4.istp.course.dto.VisibilityImpactResponseDto;
 import com.pm4.istp.course.exceptions.ChallengeAccessDeniedException;
 import com.pm4.istp.course.exceptions.ChallengeNotFoundException;
+import com.pm4.istp.course.exceptions.SubTaskAlreadySolvedException;
+import com.pm4.istp.course.exceptions.SubTaskNotFoundException;
 import com.pm4.istp.course.mappers.ChallengeMapper;
 import com.pm4.istp.course.services.ChallengeService;
 import com.pm4.istp.user.db.entities.User;
@@ -236,5 +241,150 @@ class ChallengeControllerTest {
         () -> challengeController.getVisibilityImpact(
             jwt, challengeId, ChallengeStatusEnum.PRIVATE))
         .isInstanceOf(ChallengeAccessDeniedException.class);
+  }
+
+  // ── getChallengeForPlay ────────────────────────────────────────────────────
+
+  @Test
+  void getChallengeForPlay_returnsStudentDto() {
+    UUID userId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    Jwt jwt = jwtFor(userId);
+
+    ChallengeStudentDto dto = new ChallengeStudentDto();
+    dto.setId(challengeId);
+
+    when(challengeService.getChallengeForPlay(userId, courseId, challengeId)).thenReturn(dto);
+
+    ResponseEntity<ChallengeStudentDto> response =
+        challengeController.getChallengeForPlay(jwt, challengeId, courseId);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(dto);
+  }
+
+  @Test
+  void getChallengeForPlay_whenNotEnrolled_propagatesAccessDenied() {
+    UUID userId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    Jwt jwt = jwtFor(userId);
+
+    when(challengeService.getChallengeForPlay(userId, courseId, challengeId))
+        .thenThrow(new ChallengeAccessDeniedException("not enrolled"));
+
+    assertThatThrownBy(
+        () -> challengeController.getChallengeForPlay(jwt, challengeId, courseId))
+        .isInstanceOf(ChallengeAccessDeniedException.class);
+  }
+
+  @Test
+  void getChallengeForPlay_whenChallengeNotFound_propagatesNotFound() {
+    UUID userId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    Jwt jwt = jwtFor(userId);
+
+    when(challengeService.getChallengeForPlay(userId, courseId, challengeId))
+        .thenThrow(new ChallengeNotFoundException("missing"));
+
+    assertThatThrownBy(
+        () -> challengeController.getChallengeForPlay(jwt, challengeId, courseId))
+        .isInstanceOf(ChallengeNotFoundException.class);
+  }
+
+  // ── submitSubTaskFlag ──────────────────────────────────────────────────────
+
+  @Test
+  void submitSubTaskFlag_returnsSubmissionResult() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    Jwt jwt = jwtFor(userId);
+
+    SubTaskSubmissionRequestDto request = new SubTaskSubmissionRequestDto("ISTP{ok}");
+    SubTaskSubmissionResponseDto result = new SubTaskSubmissionResponseDto(true, false, 1, 3);
+
+    when(challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{ok}"))
+        .thenReturn(result);
+
+    ResponseEntity<SubTaskSubmissionResponseDto> response =
+        challengeController.submitSubTaskFlag(jwt, challengeId, subTaskId, request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(result);
+    verify(challengeService).submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{ok}");
+  }
+
+  @Test
+  void submitSubTaskFlag_returnsIncorrectResult() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    Jwt jwt = jwtFor(userId);
+
+    SubTaskSubmissionRequestDto request = new SubTaskSubmissionRequestDto("ISTP{wrong}");
+    SubTaskSubmissionResponseDto result = new SubTaskSubmissionResponseDto(false, false, 0, 3);
+
+    when(challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{wrong}"))
+        .thenReturn(result);
+
+    ResponseEntity<SubTaskSubmissionResponseDto> response =
+        challengeController.submitSubTaskFlag(jwt, challengeId, subTaskId, request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().isCorrect()).isFalse();
+  }
+
+  @Test
+  void submitSubTaskFlag_whenNotEnrolled_propagatesAccessDenied() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    Jwt jwt = jwtFor(userId);
+
+    SubTaskSubmissionRequestDto request = new SubTaskSubmissionRequestDto("ISTP{x}");
+
+    when(challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{x}"))
+        .thenThrow(new ChallengeAccessDeniedException("not enrolled"));
+
+    assertThatThrownBy(
+        () -> challengeController.submitSubTaskFlag(jwt, challengeId, subTaskId, request))
+        .isInstanceOf(ChallengeAccessDeniedException.class);
+  }
+
+  @Test
+  void submitSubTaskFlag_whenSubTaskNotFound_propagatesNotFound() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    Jwt jwt = jwtFor(userId);
+
+    SubTaskSubmissionRequestDto request = new SubTaskSubmissionRequestDto("ISTP{x}");
+
+    when(challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{x}"))
+        .thenThrow(new SubTaskNotFoundException("missing"));
+
+    assertThatThrownBy(
+        () -> challengeController.submitSubTaskFlag(jwt, challengeId, subTaskId, request))
+        .isInstanceOf(SubTaskNotFoundException.class);
+  }
+
+  @Test
+  void submitSubTaskFlag_whenAlreadySolved_propagatesConflict() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    Jwt jwt = jwtFor(userId);
+
+    SubTaskSubmissionRequestDto request = new SubTaskSubmissionRequestDto("ISTP{x}");
+
+    when(challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{x}"))
+        .thenThrow(new SubTaskAlreadySolvedException("already done"));
+
+    assertThatThrownBy(
+        () -> challengeController.submitSubTaskFlag(jwt, challengeId, subTaskId, request))
+        .isInstanceOf(SubTaskAlreadySolvedException.class);
   }
 }

--- a/backend/src/test/java/com/pm4/istp/course/ChallengeServiceImplTest.java
+++ b/backend/src/test/java/com/pm4/istp/course/ChallengeServiceImplTest.java
@@ -30,16 +30,28 @@ import com.pm4.istp.course.db.UpdateChallengeRequest;
 import com.pm4.istp.course.db.entities.Challenge;
 import com.pm4.istp.course.db.entities.ChallengeDifficultyEnum;
 import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
+import com.pm4.istp.course.db.entities.Course;
+import com.pm4.istp.course.db.entities.CourseChallenge;
 import com.pm4.istp.course.db.entities.SubTask;
+import com.pm4.istp.course.db.entities.SubTaskCompletion;
+import com.pm4.istp.course.dto.ChallengeStudentDto;
 import com.pm4.istp.course.dto.ListChallengeResponseDto;
+import com.pm4.istp.course.dto.SubTaskSubmissionResponseDto;
 import com.pm4.istp.course.exceptions.ChallengeAccessDeniedException;
 import com.pm4.istp.course.exceptions.ChallengeNotFoundException;
+import com.pm4.istp.course.exceptions.SubTaskAlreadySolvedException;
+import com.pm4.istp.course.exceptions.SubTaskNotFoundException;
+import com.pm4.istp.course.mappers.ChallengeMapper;
 import com.pm4.istp.course.repositories.ChallengeRepository;
 import com.pm4.istp.course.repositories.CourseChallengeRepository;
+import com.pm4.istp.course.repositories.CourseEnrollmentRepository;
+import com.pm4.istp.course.repositories.SubTaskCompletionRepository;
+import com.pm4.istp.course.repositories.SubTaskRepository;
 import com.pm4.istp.course.services.impl.ChallengeServiceImpl;
 import com.pm4.istp.user.db.entities.User;
 import com.pm4.istp.user.exceptions.UserNotFoundException;
 import com.pm4.istp.user.repositories.UserRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class ChallengeServiceImplTest {
@@ -49,6 +61,10 @@ class ChallengeServiceImplTest {
   @Mock private UserRepository userRepository;
   @Mock private ChallengeRepository challengeRepository;
   @Mock private CourseChallengeRepository courseChallengeRepository;
+  @Mock private SubTaskRepository subTaskRepository;
+  @Mock private SubTaskCompletionRepository subTaskCompletionRepository;
+  @Mock private CourseEnrollmentRepository courseEnrollmentRepository;
+  @Mock private ChallengeMapper challengeMapper;
 
   @InjectMocks private ChallengeServiceImpl challengeService;
 
@@ -688,5 +704,259 @@ class ChallengeServiceImplTest {
 
     assertThat(result).isSameAs(expected);
     verify(challengeRepository).searchAvailableChallenges(userId, "sql", pageable);
+  }
+
+  // ── getChallengeForPlay ────────────────────────────────────────────────────
+
+  private Challenge buildChallengeWithCourses(UUID challengeId, UUID... courseIds) {
+    Challenge challenge = buildChallenge(challengeId, buildUser(UUID.randomUUID()),
+        ChallengeStatusEnum.PUBLIC);
+    List<CourseChallenge> ccs = new ArrayList<>();
+    for (UUID courseId : courseIds) {
+      Course course = new Course();
+      course.setId(courseId);
+      CourseChallenge cc = new CourseChallenge();
+      cc.setCourse(course);
+      cc.setChallenge(challenge);
+      ccs.add(cc);
+    }
+    challenge.setCourseChallenges(ccs);
+    return challenge;
+  }
+
+  @Test
+  void getChallengeForPlay_returnsStudentDto_whenEnrolledAndChallengeBelongsToCourse() {
+    UUID userId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    Challenge challenge = buildChallengeWithCourses(challengeId, courseId);
+
+    when(courseEnrollmentRepository.existsByCourseIdAndParticipantId(courseId, userId))
+        .thenReturn(true);
+    when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge));
+    ChallengeStudentDto dto = new ChallengeStudentDto();
+    dto.setId(challengeId);
+    when(challengeMapper.toStudentDto(challenge)).thenReturn(dto);
+
+    ChallengeStudentDto result = challengeService.getChallengeForPlay(userId, courseId, challengeId);
+
+    assertThat(result).isSameAs(dto);
+  }
+
+  @Test
+  void getChallengeForPlay_whenNotEnrolled_throwsAccessDenied() {
+    UUID userId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+
+    when(courseEnrollmentRepository.existsByCourseIdAndParticipantId(courseId, userId))
+        .thenReturn(false);
+
+    assertThatThrownBy(() -> challengeService.getChallengeForPlay(userId, courseId, challengeId))
+        .isInstanceOf(ChallengeAccessDeniedException.class);
+    verify(challengeRepository, never()).findById(any());
+  }
+
+  @Test
+  void getChallengeForPlay_whenChallengeMissing_throwsNotFound() {
+    UUID userId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+
+    when(courseEnrollmentRepository.existsByCourseIdAndParticipantId(courseId, userId))
+        .thenReturn(true);
+    when(challengeRepository.findById(challengeId)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> challengeService.getChallengeForPlay(userId, courseId, challengeId))
+        .isInstanceOf(ChallengeNotFoundException.class);
+  }
+
+  @Test
+  void getChallengeForPlay_whenChallengeNotInRequestedCourse_throwsAccessDenied() {
+    // Regression test for the authz-bypass: even if the user is enrolled in a course
+    // and the challenge exists in some *other* course, the requested courseId must
+    // actually contain the challenge.
+    UUID userId = UUID.randomUUID();
+    UUID requestedCourseId = UUID.randomUUID();
+    UUID otherCourseId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    Challenge challenge = buildChallengeWithCourses(challengeId, otherCourseId);
+
+    when(courseEnrollmentRepository.existsByCourseIdAndParticipantId(requestedCourseId, userId))
+        .thenReturn(true);
+    when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge));
+
+    assertThatThrownBy(
+        () -> challengeService.getChallengeForPlay(userId, requestedCourseId, challengeId))
+        .isInstanceOf(ChallengeAccessDeniedException.class)
+        .hasMessageContaining("not part of course");
+  }
+
+  // ── submitSubTaskFlag ──────────────────────────────────────────────────────
+
+  private SubTask buildSubTask(UUID id, Challenge parent, String flag) {
+    SubTask st = new SubTask();
+    st.setId(id);
+    st.setChallenge(parent);
+    st.setFlag(flag);
+    parent.getSubTasks().add(st);
+    return st;
+  }
+
+  @Test
+  void submitSubTaskFlag_returnsCorrectAndPersists_whenFlagMatches() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    User user = buildUser(userId);
+    Challenge challenge = buildChallengeWithCourses(challengeId, courseId);
+    SubTask subTask = buildSubTask(subTaskId, challenge, "ISTP{secret}");
+
+    when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+    when(subTaskRepository.findById(subTaskId)).thenReturn(Optional.of(subTask));
+    when(courseChallengeRepository.existsByChallengeIdAndEnrolledUserId(challengeId, userId))
+        .thenReturn(true);
+    when(subTaskCompletionRepository.existsByUserIdAndSubTaskId(userId, subTaskId))
+        .thenReturn(false);
+    when(subTaskCompletionRepository.findSolvedSubTaskIds(eq(userId), any()))
+        .thenReturn(List.of(subTaskId));
+
+    SubTaskSubmissionResponseDto result =
+        challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{secret}");
+
+    assertThat(result.isCorrect()).isTrue();
+    assertThat(result.isChallengeSolved()).isTrue();
+    verify(subTaskCompletionRepository).saveAndFlush(any(SubTaskCompletion.class));
+  }
+
+  @Test
+  void submitSubTaskFlag_returnsIncorrect_andDoesNotPersist_whenFlagMismatches() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    User user = buildUser(userId);
+    Challenge challenge = buildChallengeWithCourses(challengeId, courseId);
+    SubTask subTask = buildSubTask(subTaskId, challenge, "ISTP{secret}");
+
+    when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+    when(subTaskRepository.findById(subTaskId)).thenReturn(Optional.of(subTask));
+    when(courseChallengeRepository.existsByChallengeIdAndEnrolledUserId(challengeId, userId))
+        .thenReturn(true);
+    when(subTaskCompletionRepository.existsByUserIdAndSubTaskId(userId, subTaskId))
+        .thenReturn(false);
+    when(subTaskCompletionRepository.findSolvedSubTaskIds(eq(userId), any()))
+        .thenReturn(List.of());
+
+    SubTaskSubmissionResponseDto result =
+        challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{wrong}");
+
+    assertThat(result.isCorrect()).isFalse();
+    verify(subTaskCompletionRepository, never()).saveAndFlush(any());
+  }
+
+  @Test
+  void submitSubTaskFlag_whenSubTaskNotFound_throwsNotFound() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+
+    when(userRepository.findByIdAndDeletedAtIsNull(userId))
+        .thenReturn(Optional.of(buildUser(userId)));
+    when(subTaskRepository.findById(subTaskId)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+        () -> challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{x}"))
+        .isInstanceOf(SubTaskNotFoundException.class);
+  }
+
+  @Test
+  void submitSubTaskFlag_whenSubTaskBelongsToOtherChallenge_throwsNotFound() {
+    UUID userId = UUID.randomUUID();
+    UUID requestedChallengeId = UUID.randomUUID();
+    UUID actualChallengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    Challenge actual = buildChallengeWithCourses(actualChallengeId, courseId);
+    SubTask subTask = buildSubTask(subTaskId, actual, "ISTP{secret}");
+
+    when(userRepository.findByIdAndDeletedAtIsNull(userId))
+        .thenReturn(Optional.of(buildUser(userId)));
+    when(subTaskRepository.findById(subTaskId)).thenReturn(Optional.of(subTask));
+
+    assertThatThrownBy(
+        () -> challengeService.submitSubTaskFlag(
+            userId, requestedChallengeId, subTaskId, "ISTP{secret}"))
+        .isInstanceOf(SubTaskNotFoundException.class);
+  }
+
+  @Test
+  void submitSubTaskFlag_whenNotEnrolled_throwsAccessDenied() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    Challenge challenge = buildChallengeWithCourses(challengeId, courseId);
+    SubTask subTask = buildSubTask(subTaskId, challenge, "ISTP{secret}");
+
+    when(userRepository.findByIdAndDeletedAtIsNull(userId))
+        .thenReturn(Optional.of(buildUser(userId)));
+    when(subTaskRepository.findById(subTaskId)).thenReturn(Optional.of(subTask));
+    when(courseChallengeRepository.existsByChallengeIdAndEnrolledUserId(challengeId, userId))
+        .thenReturn(false);
+
+    assertThatThrownBy(
+        () -> challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{secret}"))
+        .isInstanceOf(ChallengeAccessDeniedException.class);
+  }
+
+  @Test
+  void submitSubTaskFlag_whenAlreadySolved_throws409() {
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    Challenge challenge = buildChallengeWithCourses(challengeId, courseId);
+    SubTask subTask = buildSubTask(subTaskId, challenge, "ISTP{secret}");
+
+    when(userRepository.findByIdAndDeletedAtIsNull(userId))
+        .thenReturn(Optional.of(buildUser(userId)));
+    when(subTaskRepository.findById(subTaskId)).thenReturn(Optional.of(subTask));
+    when(courseChallengeRepository.existsByChallengeIdAndEnrolledUserId(challengeId, userId))
+        .thenReturn(true);
+    when(subTaskCompletionRepository.existsByUserIdAndSubTaskId(userId, subTaskId))
+        .thenReturn(true);
+
+    assertThatThrownBy(
+        () -> challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{secret}"))
+        .isInstanceOf(SubTaskAlreadySolvedException.class);
+  }
+
+  @Test
+  void submitSubTaskFlag_whenConcurrentInsertHitsUniqueConstraint_throws409() {
+    // Race condition: two concurrent correct submissions both pass the
+    // existsByUserIdAndSubTaskId check, then one trips the unique constraint
+    // on insert. We must surface that as 409, not 500.
+    UUID userId = UUID.randomUUID();
+    UUID challengeId = UUID.randomUUID();
+    UUID subTaskId = UUID.randomUUID();
+    UUID courseId = UUID.randomUUID();
+    Challenge challenge = buildChallengeWithCourses(challengeId, courseId);
+    SubTask subTask = buildSubTask(subTaskId, challenge, "ISTP{secret}");
+
+    when(userRepository.findByIdAndDeletedAtIsNull(userId))
+        .thenReturn(Optional.of(buildUser(userId)));
+    when(subTaskRepository.findById(subTaskId)).thenReturn(Optional.of(subTask));
+    when(courseChallengeRepository.existsByChallengeIdAndEnrolledUserId(challengeId, userId))
+        .thenReturn(true);
+    when(subTaskCompletionRepository.existsByUserIdAndSubTaskId(userId, subTaskId))
+        .thenReturn(false);
+    when(subTaskCompletionRepository.saveAndFlush(any(SubTaskCompletion.class)))
+        .thenThrow(new DataIntegrityViolationException("unique violation"));
+
+    assertThatThrownBy(
+        () -> challengeService.submitSubTaskFlag(userId, challengeId, subTaskId, "ISTP{secret}"))
+        .isInstanceOf(SubTaskAlreadySolvedException.class);
   }
 }

--- a/backend/src/test/java/com/pm4/istp/course/CourseControllerTest.java
+++ b/backend/src/test/java/com/pm4/istp/course/CourseControllerTest.java
@@ -33,7 +33,7 @@ import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
 import com.pm4.istp.course.db.entities.Course;
 import com.pm4.istp.course.db.entities.CourseInstructor;
 import com.pm4.istp.course.dto.ChallengeCreatorResponseDto;
-import com.pm4.istp.course.dto.ChallengeDetailResponseDto;
+import com.pm4.istp.course.dto.ChallengeStudentDto;
 import com.pm4.istp.course.dto.CourseDetailInstructorResponseDto;
 import com.pm4.istp.course.dto.CourseDetailResponseDto;
 import com.pm4.istp.course.dto.CourseParticipantResponseDto;
@@ -92,6 +92,10 @@ class CourseControllerTest {
     private CourseEnrollmentRepository courseEnrollmentRepository;
     @Mock
     private CourseTopicService courseTopicService;
+    @Mock
+    private com.pm4.istp.course.repositories.SubTaskCompletionRepository subTaskCompletionRepository;
+    @Mock
+    private com.pm4.istp.course.repositories.SubTaskRepository subTaskRepository;
 
     @InjectMocks
     private CourseController courseController;
@@ -407,13 +411,13 @@ class CourseControllerTest {
 
     @Test
     void getPublicCourse_returnsOk() throws Exception {
-        ChallengeDetailResponseDto challenge1 = generateChallengeDetailResponseDto("Challenge 1",
+        ChallengeStudentDto challenge1 = generateChallengeStudentDto("Challenge 1",
                 ChallengeStatusEnum.PUBLIC, "Creator 1");
-        ChallengeDetailResponseDto challenge2 = generateChallengeDetailResponseDto("Challenge 2",
+        ChallengeStudentDto challenge2 = generateChallengeStudentDto("Challenge 2",
                 ChallengeStatusEnum.PRIVATE, "Creator 2");
-        ChallengeDetailResponseDto challenge3 = generateChallengeDetailResponseDto("Challenge 3",
+        ChallengeStudentDto challenge3 = generateChallengeStudentDto("Challenge 3",
                 ChallengeStatusEnum.DRAFT, "Creator 3");
-        ChallengeDetailResponseDto challenge4 = generateChallengeDetailResponseDto("Challenge 4",
+        ChallengeStudentDto challenge4 = generateChallengeStudentDto("Challenge 4",
                 ChallengeStatusEnum.PUBLIC, "Creator 4");
 
         Course course = new Course();
@@ -623,18 +627,19 @@ class CourseControllerTest {
     }
 
     // ── Mock object generators ────────────────────────────────────────────────
-    private ChallengeDetailResponseDto generateChallengeDetailResponseDto(String title,
+    private ChallengeStudentDto generateChallengeStudentDto(String title,
             ChallengeStatusEnum challengeStatus, String creatorName) {
         ChallengeCreatorResponseDto challengeCreatorResponseDto = new ChallengeCreatorResponseDto();
         challengeCreatorResponseDto.setId(UUID.randomUUID());
         challengeCreatorResponseDto.setName(creatorName);
 
-        ChallengeDetailResponseDto challengeDetailResponseDto = new ChallengeDetailResponseDto();
-        challengeDetailResponseDto.setTitle(title);
-        challengeDetailResponseDto.setCreator(challengeCreatorResponseDto);
-        challengeDetailResponseDto.setStatus(challengeStatus);
-
-        return challengeDetailResponseDto;
+        ChallengeStudentDto dto = new ChallengeStudentDto();
+        dto.setId(UUID.randomUUID());
+        dto.setTitle(title);
+        dto.setCreator(challengeCreatorResponseDto);
+        dto.setStatus(challengeStatus);
+        dto.setSubTasks(List.of());
+        return dto;
     }
 
     // ── Jackson helper ────────────────────────────────────────────────────────

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "openapi-fetch": "^0.17.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-imask": "^7.6.1",
         "sanitize-html": "^2.17.2"
       },
       "devDependencies": {
@@ -264,6 +265,18 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3638,6 +3651,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -4794,7 +4818,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5189,6 +5212,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/imask": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/imask/-/imask-7.6.1.tgz",
+      "integrity": "sha512-sJlIFM7eathUEMChTh9Mrfw/IgiWgJqBKq2VNbyXvBZ7ev/IlO6/KQTKlV/Fm+viQMLrFLG/zCuudrLIwgK2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.24.4"
+      },
+      "engines": {
+        "npm": ">=4.0.0"
       }
     },
     "node_modules/import-fresh": {
@@ -7654,6 +7689,22 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/react-imask": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-7.6.1.tgz",
+      "integrity": "sha512-vLNfzcCz62Yzx/GRGh5tiCph9Gbh2cZu+Tz8OiO5it2eNuuhpA0DWhhSlOtVtSJ80+Bx+vFK5De8eQ9AmbkXzA==",
+      "license": "MIT",
+      "dependencies": {
+        "imask": "^7.6.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "npm": ">=4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "openapi-fetch": "^0.17.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-imask": "^7.6.1",
     "sanitize-html": "^2.17.2"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "openapi-fetch": "^0.17.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-imask": "^7.6.1",
     "sanitize-html": "^2.17.2"
   },
   "devDependencies": {

--- a/frontend/src/app/dashboard/courses/[id]/challenges/[cid]/play/page.tsx
+++ b/frontend/src/app/dashboard/courses/[id]/challenges/[cid]/play/page.tsx
@@ -1,0 +1,35 @@
+import { Alert, Container, Group, Stack } from "@mantine/core";
+import { IconArrowLeft } from "@tabler/icons-react";
+import Link from "next/link";
+import { fetchChallengeForPlay } from "@/src/features/course/actions/challenges";
+import { ChallengePlayView } from "@/src/features/course/components/play/ChallengePlayView";
+
+export default async function PlayChallengePage({
+  params,
+}: {
+  params: Promise<{ id: string; cid: string }>;
+}) {
+  const { id: courseId, cid: challengeId } = await params;
+
+  const result = await fetchChallengeForPlay(challengeId, courseId);
+
+  if (!result.success) {
+    return (
+      <Container>
+        <Stack p="xl" gap="lg">
+          <Link href={`/dashboard/courses/${courseId}`} style={{ textDecoration: "none" }}>
+            <Group gap={6} style={{ color: "rgba(255,255,255,0.45)", fontSize: 14 }}>
+              <IconArrowLeft size={16} />
+              <span>Back to course</span>
+            </Group>
+          </Link>
+          <Alert color="red" title="Unable to load challenge">
+            {result.error}
+          </Alert>
+        </Stack>
+      </Container>
+    );
+  }
+
+  return <ChallengePlayView courseId={courseId} initialChallenge={result.data} />;
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -60,6 +60,7 @@ function RunningChallenges({
             challenges={fetchCourseResult.data.courseChallenges ?? []}
             title=""
             showIndex={false}
+            courseId={fetchCourseResult.data.id}
           />
         ) : (
           <Alert color="red" title="Failed to load challenges">

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { ColorSchemeScript, createTheme, mantineHtmlProps, MantineProvider } from "@mantine/core";
+import { Notifications } from "@mantine/notifications";
 import { Geist, Geist_Mono, Manrope, Orbitron, Space_Grotesk } from "next/font/google";
 import NextAuthSessionProvider from "@/src/features/user/components/SessionProvider";
 import "@mantine/core/styles.css";
@@ -100,6 +101,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} ${manrope.variable} ${spaceGrotesk.variable} ${orbitron.variable} antialiased`}
       >
         <MantineProvider forceColorScheme="dark" theme={theme}>
+          <Notifications position="top-right" />
           <NextAuthSessionProvider>{children}</NextAuthSessionProvider>
         </MantineProvider>
       </body>

--- a/frontend/src/features/course/actions/challenges.ts
+++ b/frontend/src/features/course/actions/challenges.ts
@@ -13,10 +13,14 @@ export type ChallengeDifficultyEnum = NonNullable<
   components["schemas"]["ChallengeDetailResponseDto"]["difficulty"]
 >;
 
+export type ChallengeCreatorResponseDto = components["schemas"]["ChallengeCreatorResponseDto"];
 export type CreateChallengeRequestDto = components["schemas"]["CreateChallengeRequestDto"];
 export type UpdateChallengeRequestDto = components["schemas"]["UpdateChallengeRequestDto"];
 export type CreateChallengeResponseDto = components["schemas"]["CreateChallengeResponseDto"];
 export type ChallengeDetailResponseDto = components["schemas"]["ChallengeDetailResponseDto"];
+export type ChallengeStudentDto = components["schemas"]["ChallengeStudentDto"];
+export type SubTaskSubmissionRequestDto = components["schemas"]["SubTaskSubmissionRequestDto"];
+export type SubTaskSubmissionResponseDto = components["schemas"]["SubTaskSubmissionResponseDto"];
 export type ListChallengeResponseDto = components["schemas"]["ListChallengeResponseDto"];
 export type PageListChallengeResponseDto = components["schemas"]["PageListChallengeResponseDto"];
 export type CourseChallengeItemDto = components["schemas"]["CourseChallengeItemDto"];
@@ -115,6 +119,34 @@ export async function previewVisibilityImpact(
   );
 }
 
+export async function fetchChallengeForPlay(
+  challengeId: string,
+  courseId: string
+): Promise<ActionResult<ChallengeStudentDto>> {
+  return await withActionResult(
+    (client) =>
+      client.GET("/api/v1/challenges/{id}/play", {
+        params: { path: { id: challengeId }, query: { courseId } },
+      }),
+    "Failed to load challenge"
+  );
+}
+
+export async function submitSubTaskFlag(
+  challengeId: string,
+  subTaskId: string,
+  flag: string
+): Promise<ActionResult<SubTaskSubmissionResponseDto>> {
+  return await withActionResult(
+    (client) =>
+      client.POST("/api/v1/challenges/{challengeId}/subtasks/{subTaskId}/submit", {
+        params: { path: { challengeId, subTaskId } },
+        body: { flag },
+      }),
+    "Failed to submit flag"
+  );
+}
+
 export async function updateCourseChallenges(
   courseId: string,
   challenges: CourseChallengeItemDto[]
@@ -123,6 +155,7 @@ export async function updateCourseChallenges(
     (client) =>
       client.PUT("/api/v1/courses/{id}/challenges", {
         params: { path: { id: courseId } },
+
         body: { challenges },
       }),
     "Failed to update course challenges"

--- a/frontend/src/features/course/components/challenges/PlayChallengeButton.tsx
+++ b/frontend/src/features/course/components/challenges/PlayChallengeButton.tsx
@@ -1,66 +1,58 @@
 "use client";
 
-import { Box, Button, Flex, Text } from "@mantine/core";
+import { Button } from "@mantine/core";
+import { IconCheck, IconPlayerPlay } from "@tabler/icons-react";
+import Link from "next/link";
 
-const darkgreen = "rgba(12, 105, 0, 1)";
-
-function ButtonWithInfoText({
-  buttonText,
-  infoText,
-  buttonColor,
+/**
+ * Action button that navigates to the play view for a challenge. Renders the
+ * appropriate label/colour based on solved state.
+ */
+export default function PlayChallengeButton({
+  href,
+  solved,
+  inProgress,
 }: {
-  buttonText: string;
-  infoText: string;
-  buttonColor: string;
+  href: string;
+  solved: boolean;
+  inProgress: boolean;
 }) {
-  return (
-    <Flex direction="column" justify="flex-end">
-      <Button mb={12} color={buttonColor} style={{ marginLeft: "auto" }}>
-        {buttonText}
+  if (solved) {
+    return (
+      <Button
+        component={Link}
+        href={href}
+        variant="light"
+        color="teal"
+        leftSection={<IconCheck size={16} />}
+        size="sm"
+      >
+        Replay
       </Button>
-      <Text size="xs">{infoText}</Text>
-    </Flex>
-  );
-}
-
-export default function PlayChallengeButton({ condition }: { condition: number }) {
-  // TODO: Currently, this is just a placeholder. Once the play challenge flow is implemented, this component needs to be finished.
-  if (condition === 0) {
-    return (
-      <ButtonWithInfoText
-        buttonText="Start"
-        infoText="You have not started this challenge yet."
-        buttonColor={darkgreen}
-      />
-    );
-  } else if (condition === 1) {
-    return (
-      <ButtonWithInfoText
-        buttonText="Restart"
-        infoText="You have already completed this challenge. You can restart it."
-        buttonColor={darkgreen}
-      />
-    );
-  } else if (condition === 2) {
-    return (
-      <Box>
-        <ButtonWithInfoText
-          buttonText="Continue"
-          infoText="Continue playing. A pod is already running."
-          buttonColor="blue"
-        />
-        <Text size="xs">
-          Pod started at |TODO: replace with real data| for course |TODO: replace with real data|
-        </Text>
-      </Box>
-    );
-  } else {
-    return (
-      <ButtonWithInfoText
-        buttonText="Continue"
-        infoText="Continue playing. This starts a new pod."
-        buttonColor="blue"
-      />
     );
   }
+  if (inProgress) {
+    return (
+      <Button
+        component={Link}
+        href={href}
+        color="blue"
+        leftSection={<IconPlayerPlay size={16} />}
+        size="sm"
+      >
+        Continue
+      </Button>
+    );
+  }
+  return (
+    <Button
+      component={Link}
+      href={href}
+      color="blue"
+      leftSection={<IconPlayerPlay size={16} />}
+      size="sm"
+    >
+      Start
+    </Button>
+  );
 }

--- a/frontend/src/features/course/components/course/CourseDetails.tsx
+++ b/frontend/src/features/course/components/course/CourseDetails.tsx
@@ -6,8 +6,25 @@ import { CourseChallengeDetailsList } from "@/src/features/course/components/man
 import { CourseJourneyCard } from "@/src/features/course/components/course/CourseJourneyCard";
 import { fetchPublicCourse } from "@/src/features/course/actions/courses";
 import type { CourseDetailInstructorResponseDto } from "@/src/features/course/actions/courses";
-import type { InstructorRoleEnum } from "@/src/shared/types/course";
+import type { ChallengeStudentDto, InstructorRoleEnum } from "@/src/shared/types/course";
 import { getSanitizedHtml } from "@/src/shared/lib/utils";
+
+function findNextChallenge(challenges: ChallengeStudentDto[]): ChallengeStudentDto | null {
+  return challenges.find((c) => !c.isSolved) ?? null;
+}
+
+function aggregateSubTaskProgress(challenges: ChallengeStudentDto[]): {
+  completed: number;
+  total: number;
+} {
+  let completed = 0;
+  let total = 0;
+  for (const challenge of challenges) {
+    completed += challenge.solvedSubTaskCount ?? 0;
+    total += challenge.totalSubTaskCount ?? challenge.subTasks?.length ?? 0;
+  }
+  return { completed, total };
+}
 
 const OWNER_ROLE: InstructorRoleEnum = "OWNER";
 
@@ -83,13 +100,26 @@ export default async function CourseDetails({
           <CourseJourneyCard
             instructor={owner}
             // lessons={undefined}    ← wire up when lesson API is ready
-            // challenges={undefined} ← wire up when challenge API is ready
+            challenges={
+              isEnrolled ? aggregateSubTaskProgress(course.courseChallenges ?? []) : undefined
+            }
+            nextChallengeHref={
+              isEnrolled
+                ? (() => {
+                    const next = findNextChallenge(course.courseChallenges ?? []);
+                    return next?.id
+                      ? `/dashboard/courses/${course.id}/challenges/${next.id}/play`
+                      : undefined;
+                  })()
+                : undefined
+            }
           />
 
           <CourseChallengeDetailsList
             challenges={course.courseChallenges ?? []}
             title="Course Challenges"
             showIndex={true}
+            courseId={isEnrolled ? course.id : undefined}
           />
 
           {/* About this course */}

--- a/frontend/src/features/course/components/course/CourseJourneyCard.tsx
+++ b/frontend/src/features/course/components/course/CourseJourneyCard.tsx
@@ -1,6 +1,7 @@
 import {
   Avatar,
   Box,
+  Button,
   Divider,
   Group,
   Progress,
@@ -9,7 +10,15 @@ import {
   ThemeIcon,
   Tooltip,
 } from "@mantine/core";
-import { IconCheck, IconClock, IconFlame, IconLock } from "@tabler/icons-react";
+import {
+  IconArrowRight,
+  IconCheck,
+  IconClock,
+  IconFlame,
+  IconLock,
+  IconTrophy,
+} from "@tabler/icons-react";
+import Link from "next/link";
 import { getInitials } from "@/src/shared/lib/utils";
 import type { CourseDetailInstructorResponseDto } from "@/src/features/course/actions/courses";
 
@@ -46,12 +55,17 @@ export interface CourseJourneyCardProps {
   lessons?: LessonsProgress;
 
   /**
-   * Challenge progress data.
-   * PLACEHOLDER — challenges are not yet implemented in the backend.
-   * When challenges are ready, pass this prop and the placeholder state
-   * will automatically be replaced with the real progress bar.
+   * Challenge progress data (aggregate sub-task progress across the course).
+   * Leave undefined to show the "coming soon" placeholder.
    */
   challenges?: ChallengesProgress;
+
+  /**
+   * Link to the next challenge the student should play. When provided, a
+   * "Start Next Challenge" button is rendered; when absent (all done or not
+   * enrolled) the button hides.
+   */
+  nextChallengeHref?: string;
 
   /**
    * When provided, renders an "Instructor" section to the right of the
@@ -169,9 +183,16 @@ function ChallengesPlaceholder() {
 // Main component
 // ---------------------------------------------------------------------------
 
-export function CourseJourneyCard({ lessons, challenges, instructor }: CourseJourneyCardProps) {
+export function CourseJourneyCard({
+  lessons,
+  challenges,
+  nextChallengeHref,
+  instructor,
+}: CourseJourneyCardProps) {
   const lessonPercent = lessons ? calcPercent(lessons.finished, lessons.total) : 0;
   const challengePercent = challenges ? calcPercent(challenges.completed, challenges.total) : 0;
+  const allChallengesComplete =
+    challenges !== undefined && challenges.total > 0 && challenges.completed === challenges.total;
 
   return (
     <Box
@@ -233,26 +254,47 @@ export function CourseJourneyCard({ lessons, challenges, instructor }: CourseJou
           {/* ── Challenges progress (or placeholder) ── */}
           {challenges ? (
             <ProgressSection
-              label="Challenges"
+              label="Sub-tasks"
               percent={challengePercent}
               color="orange"
               statLeft={
                 <StatChip
                   icon={<IconFlame size={13} color="var(--mantine-color-orange-5)" />}
-                  label={`${challenges.completed} Challenge${challenges.completed !== 1 ? "s" : ""} Completed`}
+                  label={`${challenges.completed} Sub-task${challenges.completed !== 1 ? "s" : ""} Solved`}
                 />
               }
               statRight={
                 <StatChip
                   icon={<IconClock size={13} color="var(--mantine-color-dimmed)" />}
-                  label={`${challenges.total - challenges.completed} Remaining`}
+                  label={`${Math.max(challenges.total - challenges.completed, 0)} Remaining`}
                   dimmed
                 />
               }
             />
           ) : (
-            // PLACEHOLDER: Replace with real challenges data when backend is ready
             <ChallengesPlaceholder />
+          )}
+
+          {challenges && (
+            <Group justify="flex-end">
+              {allChallengesComplete ? (
+                <Button
+                  component="span"
+                  variant="light"
+                  color="teal"
+                  leftSection={<IconTrophy size={16} />}
+                  disabled
+                >
+                  All challenges completed
+                </Button>
+              ) : nextChallengeHref ? (
+                <Link href={nextChallengeHref} style={{ textDecoration: "none" }}>
+                  <Button component="span" color="blue" rightSection={<IconArrowRight size={16} />}>
+                    Start Next Challenge
+                  </Button>
+                </Link>
+              ) : null}
+            </Group>
           )}
         </Stack>
 

--- a/frontend/src/features/course/components/management/CourseChallengeDetailsList.tsx
+++ b/frontend/src/features/course/components/management/CourseChallengeDetailsList.tsx
@@ -1,136 +1,208 @@
+"use client";
+
 import {
+  Accordion,
   Badge,
   Box,
-  Grid,
-  GridCol,
+  Divider,
   Group,
-  Paper,
-  SimpleGrid,
+  Progress,
   Stack,
   Text,
+  ThemeIcon,
   Title,
 } from "@mantine/core";
+import { IconCheck, IconCircleDashed, IconListCheck } from "@tabler/icons-react";
 import {
   getDifficultyColor,
   getStatusColor,
 } from "@/src/features/course/constants/challengeConstants";
 import PlayChallengeButton from "@/src/features/course/components/challenges/PlayChallengeButton";
 import { getSanitizedHtml } from "@/src/shared/lib/utils";
-import type { ChallengeDetailResponseDto } from "@/src/features/course/actions/challenges";
+import type { ChallengeStudentDto } from "@/src/shared/types/course";
 
-function formatDateTime(value?: string): string {
-  if (!value) return "n/a";
-
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-
-  return date.toLocaleString("de-CH", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-function formatText(value?: string | number): string {
+function formatText(value?: string | number | null): string {
   if (value === undefined || value === null || value === "") return "n/a";
   return String(value);
+}
+
+function SubTaskRow({ title, solved, index }: { title: string; solved: boolean; index: number }) {
+  return (
+    <Group gap="xs" align="center" wrap="nowrap">
+      <ThemeIcon
+        variant="light"
+        radius="xl"
+        size="sm"
+        color={solved ? "teal" : "gray"}
+        aria-label={solved ? "Solved" : "Not solved"}
+      >
+        {solved ? <IconCheck size={12} /> : <IconCircleDashed size={12} />}
+      </ThemeIcon>
+      <Text size="sm" c={solved ? "teal.3" : undefined} td={solved ? "line-through" : undefined}>
+        {index + 1}. {title}
+      </Text>
+    </Group>
+  );
 }
 
 export function CourseChallengeDetailsList({
   challenges,
   title,
   showIndex,
+  courseId,
 }: {
-  challenges: ChallengeDetailResponseDto[];
+  challenges: ChallengeStudentDto[];
   title: string;
   showIndex: boolean;
+  /** If provided, "Play" buttons link into the play view for this course. */
+  courseId?: string;
 }) {
+  if (challenges.length === 0) return null;
+
+  const totalSolved = challenges.filter((c) => c.isSolved).length;
+
   return (
-    <>
-      {challenges.length === 0 ? (
-        <></>
-      ) : (
-        <Stack gap="md">
-          <Group justify="space-between" align="center">
-            <Title order={3}>{title}</Title>
-            <Text size="sm" c="dimmed">
-              {challenges.length} challenges
-            </Text>
-          </Group>
-          <Stack gap="sm">
-            {challenges.map((challenge, index) => {
-              const challengeTitle = showIndex
-                ? "#" + (index + 1) + " " + formatText(challenge.title)
-                : formatText(challenge.title);
-              const sanitizedDescription =
-                challenge.description === undefined ? "" : getSanitizedHtml(challenge.description);
+    <Stack gap="md">
+      <Group justify="space-between" align="center">
+        {title ? <Title order={3}>{title}</Title> : <span />}
+        <Group gap="xs">
+          <IconListCheck size={16} color="rgba(255,255,255,0.5)" />
+          <Text size="sm" c="dimmed">
+            {totalSolved}/{challenges.length} completed
+          </Text>
+        </Group>
+      </Group>
 
-              return (
-                <Paper
-                  key={challenge.id}
-                  p="md"
-                  radius="md"
-                  withBorder
-                  style={{ background: "rgba(255,255,255,0.02)" }}
-                >
-                  <Grid>
-                    <GridCol span={12}>
-                      <Title order={4} style={{ fontSize: "1rem" }}>
-                        {challengeTitle}
-                      </Title>
-                    </GridCol>
+      <Accordion variant="separated" radius="md" multiple>
+        {challenges.map((challenge, index) => {
+          if (challenge.id === undefined) return null;
+          const challengeTitle = showIndex
+            ? `#${index + 1} ${formatText(challenge.title)}`
+            : formatText(challenge.title);
+          const sanitizedDescription = challenge.description
+            ? getSanitizedHtml(challenge.description)
+            : "";
+          const subTasks = challenge.subTasks ?? [];
+          const solvedCount = challenge.solvedSubTaskCount ?? 0;
+          const totalCount = challenge.totalSubTaskCount ?? subTasks.length;
+          const percent = totalCount === 0 ? 0 : Math.round((solvedCount / totalCount) * 100);
+          const playHref = courseId
+            ? `/dashboard/courses/${courseId}/challenges/${challenge.id}/play`
+            : undefined;
 
-                    <GridCol span={9}>
-                      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="xs">
-                        <Text size="sm">
-                          Short Description: {formatText(challenge.shortDescription)}
+          return (
+            <Accordion.Item
+              key={challenge.id}
+              value={challenge.id}
+              style={{ background: "rgba(255,255,255,0.02)" }}
+            >
+              <Accordion.Control>
+                <Group justify="space-between" align="center" wrap="nowrap" pr="md">
+                  <Group gap="sm" align="center" wrap="nowrap" style={{ minWidth: 0 }}>
+                    {challenge.isSolved ? (
+                      <ThemeIcon
+                        color="teal"
+                        variant="light"
+                        radius="xl"
+                        size="md"
+                        aria-label="Challenge solved"
+                      >
+                        <IconCheck size={16} />
+                      </ThemeIcon>
+                    ) : (
+                      <ThemeIcon
+                        color="gray"
+                        variant="light"
+                        radius="xl"
+                        size="md"
+                        aria-label="Challenge not solved"
+                      >
+                        <IconCircleDashed size={16} />
+                      </ThemeIcon>
+                    )}
+                    <Text fw={600} truncate>
+                      {challengeTitle}
+                    </Text>
+                  </Group>
+                  <Group gap="xs" wrap="nowrap">
+                    <Badge variant="light" color={getStatusColor(challenge.status ?? "")}>
+                      {formatText(challenge.status)}
+                    </Badge>
+                    <Badge variant="light" color={getDifficultyColor(challenge.difficulty ?? "")}>
+                      {formatText(challenge.difficulty)}
+                    </Badge>
+                    <Badge
+                      variant="light"
+                      color={challenge.isSolved ? "teal" : "blue"}
+                      aria-label={`${solvedCount} of ${totalCount} sub-tasks solved`}
+                    >
+                      {solvedCount}/{totalCount}
+                    </Badge>
+                  </Group>
+                </Group>
+              </Accordion.Control>
+              <Accordion.Panel>
+                <Stack gap="md">
+                  <Stack gap={4}>
+                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                      Progress
+                    </Text>
+                    <Progress
+                      value={percent}
+                      color={challenge.isSolved ? "teal" : "blue"}
+                      radius="xl"
+                      size="sm"
+                    />
+                  </Stack>
+
+                  {challenge.shortDescription && (
+                    <Text size="sm" c="dimmed">
+                      {challenge.shortDescription}
+                    </Text>
+                  )}
+
+                  {sanitizedDescription && (
+                    <Box
+                      className="course-description"
+                      style={{ fontSize: "var(--mantine-font-size-sm)" }}
+                      dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
+                    />
+                  )}
+
+                  {subTasks.length > 0 && (
+                    <>
+                      <Divider my={4} />
+                      <Stack gap={6}>
+                        <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                          Sub-tasks
                         </Text>
-                        <Text size="sm">Creator: {formatText(challenge.creator?.name)}</Text>
-                        <Text size="sm">Created At: {formatDateTime(challenge.createdAt)}</Text>
-                        <Text size="sm">Updated At: {formatDateTime(challenge.updatedAt)}</Text>
-                        <Text size="sm">Max Score: {formatText(challenge.maxScore)}</Text>
-                      </SimpleGrid>
-
-                      <Box>
-                        <Text size="sm" fw={600} mt={30} mb={4}>
-                          Description:
-                        </Text>
-                        <Box
-                          className="course-description"
-                          style={{ fontSize: "var(--mantine-font-size-sm)" }}
-                          dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
-                        />
-                      </Box>
-                    </GridCol>
-
-                    <GridCol span={3}>
-                      <Stack gap="xs" align="flex-end">
-                        <Group gap="xs">
-                          <Badge variant="light" color={getStatusColor(challenge.status ?? "")}>
-                            {formatText(challenge.status)}
-                          </Badge>
-                          <Badge
-                            variant="light"
-                            color={getDifficultyColor(challenge.difficulty ?? "")}
-                          >
-                            {formatText(challenge.difficulty)}
-                          </Badge>
-                        </Group>
-
-                        <Box my={30} style={{ width: 200 }}>
-                          <PlayChallengeButton condition={2} />
-                        </Box>
+                        {subTasks.map((st, idx) => (
+                          <SubTaskRow
+                            key={st.id ?? idx}
+                            title={st.title ?? ""}
+                            solved={st.isSolved ?? false}
+                            index={idx}
+                          />
+                        ))}
                       </Stack>
-                    </GridCol>
-                  </Grid>
-                </Paper>
-              );
-            })}
-          </Stack>
-        </Stack>
-      )}
-    </>
+                    </>
+                  )}
+
+                  {playHref && (
+                    <Group justify="flex-end">
+                      <PlayChallengeButton
+                        href={playHref}
+                        solved={challenge.isSolved ?? false}
+                        inProgress={solvedCount > 0 && !challenge.isSolved}
+                      />
+                    </Group>
+                  )}
+                </Stack>
+              </Accordion.Panel>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
+    </Stack>
   );
 }

--- a/frontend/src/features/course/components/play/ChallengePlayView.tsx
+++ b/frontend/src/features/course/components/play/ChallengePlayView.tsx
@@ -263,12 +263,7 @@ export function ChallengePlayView({
 
             {/* ── Sub-task working area ── */}
             {current && (
-              <Paper
-                withBorder
-                radius="md"
-                p="md"
-                style={{ background: "rgba(255,255,255,0.03)" }}
-              >
+              <Paper withBorder radius="md" p="md" style={{ background: "rgba(255,255,255,0.03)" }}>
                 <Stack gap="md">
                   <Stack gap={4}>
                     <Group gap="xs" align="center">

--- a/frontend/src/features/course/components/play/ChallengePlayView.tsx
+++ b/frontend/src/features/course/components/play/ChallengePlayView.tsx
@@ -186,134 +186,168 @@ export function ChallengePlayView({
           style={{ background: "rgba(255,255,255,0.02)", overflow: "auto" }}
         >
           <Stack gap="lg">
-            <Stack gap={4}>
-              <Title order={2}>{challenge.title}</Title>
-              {challenge.shortDescription && (
-                <Text c="dimmed" size="sm">
-                  {challenge.shortDescription}
+            {/* ── Challenge block ── */}
+            <Stack gap="md">
+              <Stack gap={6}>
+                <Text
+                  size="xs"
+                  tt="uppercase"
+                  c="dimmed"
+                  fw={700}
+                  style={{ letterSpacing: "0.08em" }}
+                >
+                  Challenge
                 </Text>
+                <Title order={2} style={{ lineHeight: 1.2 }}>
+                  {challenge.title}
+                </Title>
+                {challenge.shortDescription && (
+                  <Text c="dimmed" size="sm">
+                    {challenge.shortDescription}
+                  </Text>
+                )}
+              </Stack>
+
+              <Stack gap={6}>
+                <Group justify="space-between" align="center">
+                  <Text size="xs" tt="uppercase" c="dimmed" fw={700}>
+                    Progress
+                  </Text>
+                  <Text size="xs" fw={600} c={allSolved ? "teal.3" : "blue.3"}>
+                    {solvedCount} / {total} sub-tasks
+                  </Text>
+                </Group>
+                <Progress
+                  value={percent}
+                  color={allSolved ? "teal" : "blue"}
+                  radius="xl"
+                  size="sm"
+                />
+              </Stack>
+
+              {sanitizedChallengeDescription && (
+                <Box
+                  className="course-description"
+                  style={{ fontSize: "var(--mantine-font-size-sm)" }}
+                  dangerouslySetInnerHTML={{ __html: sanitizedChallengeDescription }}
+                />
               )}
             </Stack>
 
-            <Stack gap={6}>
-              <Group justify="space-between" align="center">
-                <Text size="xs" tt="uppercase" c="dimmed" fw={700}>
-                  Progress
-                </Text>
-                <Text size="xs" fw={600} c={allSolved ? "teal.3" : "blue.3"}>
-                  {solvedCount} / {total} sub-tasks
-                </Text>
-              </Group>
-              <Progress value={percent} color={allSolved ? "teal" : "blue"} radius="xl" size="sm" />
-            </Stack>
+            <Divider />
 
-            {sanitizedChallengeDescription && (
-              <Box
-                className="course-description"
-                style={{ fontSize: "var(--mantine-font-size-sm)" }}
-                dangerouslySetInnerHTML={{ __html: sanitizedChallengeDescription }}
-              />
-            )}
-
+            {/* ── Sub-task navigation: compact, just numbers ── */}
             {total > 0 && (
-              <>
-                <Divider />
-                <Stepper
-                  active={activeStep}
-                  onStepClick={goToStep}
-                  allowNextStepsSelect={false}
-                  size="sm"
-                  iconSize={32}
-                >
-                  {subTasks.map((st, idx) => (
-                    <Stepper.Step
-                      key={st.id}
-                      label={`Sub-task ${idx + 1}`}
-                      description={st.title}
-                      completedIcon={<IconCheck size={16} />}
-                      icon={
-                        st.isSolved ? (
-                          <IconCheck size={16} />
-                        ) : idx > 0 && !subTasks[idx - 1]?.isSolved ? (
-                          <IconLock size={14} />
-                        ) : undefined
-                      }
-                    />
-                  ))}
-                </Stepper>
-              </>
+              <Stepper
+                active={activeStep}
+                onStepClick={goToStep}
+                allowNextStepsSelect={false}
+                size="xs"
+                iconSize={28}
+              >
+                {subTasks.map((st, idx) => (
+                  <Stepper.Step
+                    key={st.id}
+                    completedIcon={<IconCheck size={14} />}
+                    icon={
+                      st.isSolved ? (
+                        <IconCheck size={14} />
+                      ) : idx > 0 && !subTasks[idx - 1]?.isSolved ? (
+                        <IconLock size={12} />
+                      ) : undefined
+                    }
+                  />
+                ))}
+              </Stepper>
             )}
 
+            {/* ── Sub-task working area ── */}
             {current && (
-              <Stack gap="md">
-                <Stack gap={4}>
-                  <Text size="xs" tt="uppercase" c="dimmed" fw={700}>
-                    Current sub-task
-                  </Text>
-                  <Title order={4}>{current.title}</Title>
-                </Stack>
+              <Paper
+                withBorder
+                radius="md"
+                p="md"
+                style={{ background: "rgba(255,255,255,0.03)" }}
+              >
+                <Stack gap="md">
+                  <Stack gap={4}>
+                    <Group gap="xs" align="center">
+                      <Text size="xs" tt="uppercase" c="dimmed" fw={700}>
+                        Sub-task {activeStep + 1} of {total}
+                      </Text>
+                      {current.isSolved && (
+                        <Badge variant="light" color="teal" size="xs">
+                          Solved
+                        </Badge>
+                      )}
+                    </Group>
+                    <Title order={4} style={{ lineHeight: 1.3 }}>
+                      {current.title}
+                    </Title>
+                  </Stack>
 
-                {sanitizedSubTaskDescription && (
-                  <Box
-                    className="course-description"
-                    style={{ fontSize: "var(--mantine-font-size-sm)" }}
-                    dangerouslySetInnerHTML={{ __html: sanitizedSubTaskDescription }}
-                  />
-                )}
-
-                <Stack gap="xs">
-                  <Text size="xs" tt="uppercase" c="dimmed" fw={700}>
-                    Submit Flag
-                  </Text>
-                  <Group gap="xs" align="flex-end">
-                    <TextInput
-                      value={current.isSolved ? (current.solvedFlag ?? "") : flagInput}
-                      onChange={(e) => {
-                        if (!current.isSolved) setFlagInput(e.currentTarget.value);
-                      }}
-                      placeholder="ISTP{...}"
-                      readOnly={current.isSolved}
-                      disabled={submitting}
-                      style={{ flex: 1 }}
-                      styles={{ input: { fontFamily: "var(--font-geist-mono), monospace" } }}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" && !current.isSolved && !submitting) {
-                          e.preventDefault();
-                          void handleSubmit();
-                        }
-                      }}
-                      aria-label="Flag input"
+                  {sanitizedSubTaskDescription && (
+                    <Box
+                      className="course-description"
+                      style={{ fontSize: "var(--mantine-font-size-sm)" }}
+                      dangerouslySetInnerHTML={{ __html: sanitizedSubTaskDescription }}
                     />
+                  )}
+
+                  <Stack gap="xs">
+                    <Text size="xs" tt="uppercase" c="dimmed" fw={700}>
+                      Submit Flag
+                    </Text>
+                    <Group gap="xs" align="flex-end">
+                      <TextInput
+                        value={current.isSolved ? (current.solvedFlag ?? "") : flagInput}
+                        onChange={(e) => {
+                          if (!current.isSolved) setFlagInput(e.currentTarget.value);
+                        }}
+                        placeholder="ISTP{...}"
+                        readOnly={current.isSolved}
+                        disabled={submitting}
+                        style={{ flex: 1 }}
+                        styles={{ input: { fontFamily: "var(--font-geist-mono), monospace" } }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" && !current.isSolved && !submitting) {
+                            e.preventDefault();
+                            void handleSubmit();
+                          }
+                        }}
+                        aria-label="Flag input"
+                      />
+                      <Button
+                        onClick={() => void handleSubmit()}
+                        disabled={current.isSolved}
+                        loading={submitting}
+                        color={current.isSolved ? "teal" : "blue"}
+                        leftSection={current.isSolved ? <IconCheck size={16} /> : undefined}
+                      >
+                        {current.isSolved ? "Solved" : "Submit"}
+                      </Button>
+                    </Group>
+                  </Stack>
+
+                  <Group justify="space-between">
                     <Button
-                      onClick={() => void handleSubmit()}
-                      disabled={current.isSolved}
-                      loading={submitting}
-                      color={current.isSolved ? "teal" : "blue"}
-                      leftSection={current.isSolved ? <IconCheck size={16} /> : undefined}
+                      variant="subtle"
+                      leftSection={<IconArrowLeft size={16} />}
+                      onClick={() => goToStep(activeStep - 1)}
+                      disabled={activeStep === 0}
                     >
-                      {current.isSolved ? "Solved" : "Submit"}
+                      Previous
+                    </Button>
+                    <Button
+                      rightSection={<IconArrowRight size={16} />}
+                      onClick={() => goToStep(activeStep + 1)}
+                      disabled={!current.isSolved || activeStep >= total - 1}
+                    >
+                      Next
                     </Button>
                   </Group>
                 </Stack>
-
-                <Group justify="space-between">
-                  <Button
-                    variant="subtle"
-                    leftSection={<IconArrowLeft size={16} />}
-                    onClick={() => goToStep(activeStep - 1)}
-                    disabled={activeStep === 0}
-                  >
-                    Previous
-                  </Button>
-                  <Button
-                    rightSection={<IconArrowRight size={16} />}
-                    onClick={() => goToStep(activeStep + 1)}
-                    disabled={!current.isSolved || activeStep >= total - 1}
-                  >
-                    Next
-                  </Button>
-                </Group>
-              </Stack>
+              </Paper>
             )}
 
             {allSolved && (

--- a/frontend/src/features/course/components/play/ChallengePlayView.tsx
+++ b/frontend/src/features/course/components/play/ChallengePlayView.tsx
@@ -1,0 +1,435 @@
+"use client";
+
+import {
+  ActionIcon,
+  Badge,
+  Box,
+  Button,
+  Divider,
+  Group,
+  Paper,
+  Progress,
+  Stack,
+  Stepper,
+  Text,
+  TextInput,
+  Title,
+  Tooltip,
+} from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import {
+  IconArrowLeft,
+  IconArrowRight,
+  IconCheck,
+  IconExternalLink,
+  IconLock,
+  IconMaximize,
+  IconMinimize,
+  IconTrophy,
+} from "@tabler/icons-react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { submitSubTaskFlag } from "@/src/features/course/actions/challenges";
+import {
+  getDifficultyColor,
+  getStatusColor,
+} from "@/src/features/course/constants/challengeConstants";
+import { getSanitizedHtml } from "@/src/shared/lib/utils";
+import type { ChallengeStudentDto, SubTaskStudentDto } from "@/src/shared/types/course";
+
+const FLAG_PATTERN = /^ISTP\{[A-Za-z0-9_]+\}$/;
+const YOUTUBE_EMBED_URL = "https://www.youtube.com/embed/QDqPXFgLirM?list=RDQDqPXFgLirM";
+const YOUTUBE_WATCH_URL = "https://www.youtube.com/watch?v=QDqPXFgLirM&list=RDQDqPXFgLirM";
+
+function pickInitialStep(subTasks: SubTaskStudentDto[]): number {
+  const firstUnsolved = subTasks.findIndex((st) => !st.isSolved);
+  return firstUnsolved === -1 ? Math.max(subTasks.length - 1, 0) : firstUnsolved;
+}
+
+export function ChallengePlayView({
+  courseId,
+  initialChallenge,
+}: {
+  courseId: string;
+  initialChallenge: ChallengeStudentDto;
+}) {
+  const [challenge, setChallenge] = useState<ChallengeStudentDto>(initialChallenge);
+  const [activeStep, setActiveStep] = useState<number>(() =>
+    pickInitialStep(initialChallenge.subTasks ?? [])
+  );
+  const [flagInput, setFlagInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [labFullscreen, setLabFullscreen] = useState(false);
+
+  const subTasks = challenge.subTasks ?? [];
+  const total = subTasks.length;
+  const solvedCount = challenge.solvedSubTaskCount ?? 0;
+  const percent = total === 0 ? 0 : Math.round((solvedCount / total) * 100);
+  const current = subTasks[activeStep] ?? null;
+  const allSolved = challenge.isSolved ?? false;
+  const sanitizedChallengeDescription = useMemo(
+    () => (challenge.description ? getSanitizedHtml(challenge.description) : ""),
+    [challenge.description]
+  );
+  const sanitizedSubTaskDescription = useMemo(
+    () => (current?.description ? getSanitizedHtml(current.description) : ""),
+    [current]
+  );
+
+  function updateSubTaskSolved(subTaskId: string, submittedFlag: string) {
+    setChallenge((prev) => {
+      const updatedSubTasks = (prev.subTasks ?? []).map((st) =>
+        st.id === subTaskId ? { ...st, isSolved: true, solvedFlag: submittedFlag } : st
+      );
+      const newSolved = updatedSubTasks.filter((st) => st.isSolved).length;
+      return {
+        ...prev,
+        subTasks: updatedSubTasks,
+        solvedSubTaskCount: newSolved,
+        isSolved: newSolved === updatedSubTasks.length && updatedSubTasks.length > 0,
+      };
+    });
+  }
+
+  async function handleSubmit() {
+    if (!current || !current.id || !challenge.id) return;
+    if (!FLAG_PATTERN.test(flagInput)) {
+      notifications.show({
+        color: "red",
+        title: "Invalid flag format",
+        message: "Flags must match ISTP{...} (letters, digits, underscores).",
+      });
+      return;
+    }
+
+    setSubmitting(true);
+    const result = await submitSubTaskFlag(challenge.id, current.id, flagInput);
+    setSubmitting(false);
+
+    if (!result.success) {
+      notifications.show({
+        color: "red",
+        title: "Submission failed",
+        message: result.error,
+      });
+      return;
+    }
+
+    if (result.data.isCorrect && current.id) {
+      updateSubTaskSolved(current.id, flagInput);
+      notifications.show({
+        color: "teal",
+        title: "Correct flag!",
+        message: result.data.isChallengeSolved
+          ? "Challenge completed. Nice work!"
+          : "Sub-task solved. Continue to the next one.",
+      });
+    } else {
+      notifications.show({
+        color: "red",
+        title: "Incorrect flag",
+        message: "Not quite — double-check and try again.",
+      });
+    }
+  }
+
+  function goToStep(step: number) {
+    if (step < 0 || step >= total) return;
+    // Allow navigating only to solved steps or the first unsolved one.
+    const firstUnsolved = subTasks.findIndex((st) => !st.isSolved);
+    const maxReachable = firstUnsolved === -1 ? total - 1 : firstUnsolved;
+    if (step > maxReachable) return;
+    setActiveStep(step);
+    setFlagInput("");
+  }
+
+  return (
+    <Box style={{ display: "flex", flexDirection: "column", minHeight: "calc(100vh - 60px)" }}>
+      {/* Header */}
+      <Group justify="space-between" align="center" px="lg" py="md">
+        <Link href={`/dashboard/courses/${courseId}`} style={{ textDecoration: "none" }}>
+          <Group gap={6} style={{ color: "rgba(255,255,255,0.6)" }}>
+            <IconArrowLeft size={16} />
+            <Text size="sm">Back to course</Text>
+          </Group>
+        </Link>
+        <Group gap="xs">
+          <Badge variant="light" color={getStatusColor(challenge.status ?? "")}>
+            {challenge.status}
+          </Badge>
+          <Badge variant="light" color={getDifficultyColor(challenge.difficulty ?? "")}>
+            {challenge.difficulty}
+          </Badge>
+          {allSolved && (
+            <Badge variant="light" color="teal" leftSection={<IconTrophy size={12} />}>
+              Completed
+            </Badge>
+          )}
+        </Group>
+      </Group>
+
+      <Box
+        style={{
+          display: "grid",
+          gridTemplateColumns: labFullscreen ? "1fr" : "minmax(0, 1fr) minmax(0, 1fr)",
+          gap: "1rem",
+          padding: "0 1rem 1rem",
+          flex: 1,
+          minHeight: 0,
+        }}
+      >
+        {/* LEFT: Challenge description + sub-task stepper */}
+        <Paper
+          withBorder
+          radius="md"
+          p="lg"
+          style={{ background: "rgba(255,255,255,0.02)", overflow: "auto" }}
+        >
+          <Stack gap="lg">
+            <Stack gap={4}>
+              <Title order={2}>{challenge.title}</Title>
+              {challenge.shortDescription && (
+                <Text c="dimmed" size="sm">
+                  {challenge.shortDescription}
+                </Text>
+              )}
+            </Stack>
+
+            <Stack gap={6}>
+              <Group justify="space-between" align="center">
+                <Text size="xs" tt="uppercase" c="dimmed" fw={700}>
+                  Progress
+                </Text>
+                <Text size="xs" fw={600} c={allSolved ? "teal.3" : "blue.3"}>
+                  {solvedCount} / {total} sub-tasks
+                </Text>
+              </Group>
+              <Progress value={percent} color={allSolved ? "teal" : "blue"} radius="xl" size="sm" />
+            </Stack>
+
+            {sanitizedChallengeDescription && (
+              <Box
+                className="course-description"
+                style={{ fontSize: "var(--mantine-font-size-sm)" }}
+                dangerouslySetInnerHTML={{ __html: sanitizedChallengeDescription }}
+              />
+            )}
+
+            {total > 0 && (
+              <>
+                <Divider />
+                <Stepper
+                  active={activeStep}
+                  onStepClick={goToStep}
+                  allowNextStepsSelect={false}
+                  size="sm"
+                  iconSize={32}
+                >
+                  {subTasks.map((st, idx) => (
+                    <Stepper.Step
+                      key={st.id}
+                      label={`Sub-task ${idx + 1}`}
+                      description={st.title}
+                      completedIcon={<IconCheck size={16} />}
+                      icon={
+                        st.isSolved ? (
+                          <IconCheck size={16} />
+                        ) : idx > 0 && !subTasks[idx - 1]?.isSolved ? (
+                          <IconLock size={14} />
+                        ) : undefined
+                      }
+                    />
+                  ))}
+                </Stepper>
+              </>
+            )}
+
+            {current && (
+              <Stack gap="md">
+                <Stack gap={4}>
+                  <Text size="xs" tt="uppercase" c="dimmed" fw={700}>
+                    Current sub-task
+                  </Text>
+                  <Title order={4}>{current.title}</Title>
+                </Stack>
+
+                {sanitizedSubTaskDescription && (
+                  <Box
+                    className="course-description"
+                    style={{ fontSize: "var(--mantine-font-size-sm)" }}
+                    dangerouslySetInnerHTML={{ __html: sanitizedSubTaskDescription }}
+                  />
+                )}
+
+                <Stack gap="xs">
+                  <Text size="xs" tt="uppercase" c="dimmed" fw={700}>
+                    Submit Flag
+                  </Text>
+                  <Group gap="xs" align="flex-end">
+                    <TextInput
+                      value={current.isSolved ? (current.solvedFlag ?? "") : flagInput}
+                      onChange={(e) => {
+                        if (!current.isSolved) setFlagInput(e.currentTarget.value);
+                      }}
+                      placeholder="ISTP{...}"
+                      readOnly={current.isSolved}
+                      disabled={submitting}
+                      style={{ flex: 1 }}
+                      styles={{ input: { fontFamily: "var(--font-geist-mono), monospace" } }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && !current.isSolved && !submitting) {
+                          e.preventDefault();
+                          void handleSubmit();
+                        }
+                      }}
+                      aria-label="Flag input"
+                    />
+                    <Button
+                      onClick={() => void handleSubmit()}
+                      disabled={current.isSolved}
+                      loading={submitting}
+                      color={current.isSolved ? "teal" : "blue"}
+                      leftSection={current.isSolved ? <IconCheck size={16} /> : undefined}
+                    >
+                      {current.isSolved ? "Solved" : "Submit"}
+                    </Button>
+                  </Group>
+                </Stack>
+
+                <Group justify="space-between">
+                  <Button
+                    variant="subtle"
+                    leftSection={<IconArrowLeft size={16} />}
+                    onClick={() => goToStep(activeStep - 1)}
+                    disabled={activeStep === 0}
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    rightSection={<IconArrowRight size={16} />}
+                    onClick={() => goToStep(activeStep + 1)}
+                    disabled={!current.isSolved || activeStep >= total - 1}
+                  >
+                    Next
+                  </Button>
+                </Group>
+              </Stack>
+            )}
+
+            {allSolved && (
+              <Paper
+                withBorder
+                radius="md"
+                p="md"
+                style={{ background: "rgba(20, 184, 166, 0.08)" }}
+              >
+                <Group gap="sm">
+                  <IconTrophy size={20} color="var(--mantine-color-teal-4)" />
+                  <Stack gap={2}>
+                    <Text fw={600}>Challenge completed</Text>
+                    <Text size="sm" c="dimmed">
+                      You solved every sub-task. Well done!
+                    </Text>
+                  </Stack>
+                </Group>
+              </Paper>
+            )}
+          </Stack>
+        </Paper>
+
+        {/* RIGHT: Lab environment (placeholder iframe) */}
+        {!labFullscreen && (
+          <Paper
+            withBorder
+            radius="md"
+            p={0}
+            style={{
+              background: "rgba(255,255,255,0.02)",
+              display: "flex",
+              flexDirection: "column",
+              minHeight: 420,
+              overflow: "hidden",
+            }}
+          >
+            <Group
+              justify="space-between"
+              align="center"
+              px="md"
+              py="xs"
+              style={{ borderBottom: "1px solid rgba(255,255,255,0.08)" }}
+            >
+              <Group gap="xs">
+                <Text size="sm" fw={600}>
+                  Lab Environment
+                </Text>
+                <Badge size="xs" variant="light" color="yellow">
+                  Coming soon
+                </Badge>
+              </Group>
+              <Group gap={4}>
+                <Tooltip label="Open lab in new tab">
+                  <ActionIcon
+                    component="a"
+                    href={YOUTUBE_WATCH_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    variant="subtle"
+                    aria-label="Open lab in new tab"
+                  >
+                    <IconExternalLink size={16} />
+                  </ActionIcon>
+                </Tooltip>
+                <Tooltip label="Fullscreen description">
+                  <ActionIcon
+                    variant="subtle"
+                    onClick={() => setLabFullscreen(true)}
+                    aria-label="Toggle fullscreen"
+                  >
+                    <IconMaximize size={16} />
+                  </ActionIcon>
+                </Tooltip>
+              </Group>
+            </Group>
+            <Box style={{ position: "relative", flex: 1 }}>
+              <iframe
+                src={YOUTUBE_EMBED_URL}
+                title="Lab environment placeholder"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+                style={{
+                  position: "absolute",
+                  inset: 0,
+                  width: "100%",
+                  height: "100%",
+                  border: 0,
+                }}
+              />
+            </Box>
+          </Paper>
+        )}
+      </Box>
+
+      {labFullscreen && (
+        <Group justify="flex-end" px="lg" pb="md">
+          <Button
+            variant="subtle"
+            leftSection={<IconExternalLink size={16} />}
+            component="a"
+            href={YOUTUBE_WATCH_URL}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Open lab in new tab
+          </Button>
+          <Button
+            variant="light"
+            leftSection={<IconMinimize size={16} />}
+            onClick={() => setLabFullscreen(false)}
+          >
+            Show lab pane
+          </Button>
+        </Group>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/shared/lib/api/schema.d.ts
+++ b/frontend/src/shared/lib/api/schema.d.ts
@@ -80,6 +80,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/admin/courses/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: operations["updateCourse_1"];
+    post?: never;
+    delete: operations["deleteCourse_1"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/admin/config": {
     parameters: {
       query?: never;
@@ -91,6 +107,22 @@ export interface paths {
     put: operations["updateAdminConfig"];
     post: operations["uploadAndStoreAdminConfig"];
     delete: operations["deleteAdminConfig"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/admin/challenges/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: operations["updateChallenge_1"];
+    post?: never;
+    delete: operations["deleteChallenge_1"];
     options?: never;
     head?: never;
     patch?: never;
@@ -220,6 +252,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/challenges/{challengeId}/subtasks/{subTaskId}/submit": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Submit a flag for a sub-task
+     * @description Validates the submitted flag against the stored plaintext flag (case-sensitive). On a correct submission the sub-task is marked as solved for the authenticated user. Already-solved sub-tasks cannot be re-submitted.
+     */
+    post: operations["submitSubTaskFlag"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/k8s/pods": {
     parameters: {
       query?: never;
@@ -230,6 +282,22 @@ export interface paths {
     get?: never;
     put?: never;
     post: operations["createPod"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/admin/topics": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["listTopics"];
+    put?: never;
+    post: operations["addTopic"];
     delete?: never;
     options?: never;
     head?: never;
@@ -260,6 +328,26 @@ export interface paths {
       cookie?: never;
     };
     get: operations["listCollaboratorUsers_1"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/courses/topics": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List course topics
+     * @description Returns the list of allowed course topics for topic selection UIs.
+     */
+    get: operations["listCourseTopics"];
     put?: never;
     post?: never;
     delete?: never;
@@ -348,6 +436,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/challenges/{id}/play": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get a challenge in student play view
+     * @description Returns a challenge formatted for students (no sub-task flags, with per-user solved progress). Caller must be enrolled in the given course, and the challenge must belong to it.
+     */
+    get: operations["getChallengeForPlay"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/challenges/search": {
     parameters: {
       query?: never;
@@ -368,6 +476,58 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/admin/courses": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["listCourses_1"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/admin/challenges": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["listChallenges_1"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/courses/{id}/participants/{participantId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Remove a participant from a course
+     * @description Removes a student (participant) from a course. Only accessible to the owner.
+     */
+    delete: operations["removeParticipant"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/k8s/pods/{instanceName}": {
     parameters: {
       query?: never;
@@ -379,6 +539,22 @@ export interface paths {
     put?: never;
     post?: never;
     delete: operations["deletePod"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/admin/topics/{value}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: operations["deleteTopic"];
     options?: never;
     head?: never;
     patch?: never;
@@ -539,6 +715,17 @@ export interface components {
       /** Format: int32 */
       orderIndex?: number;
     };
+    AdminUpdateCourseRequestDto: {
+      title: string;
+      description?: string;
+      shortDescription?: string;
+      topic?: string;
+      imageUrl?: string;
+      private?: boolean;
+      published?: boolean;
+      isPublished?: boolean;
+      isPrivate?: boolean;
+    };
     AdminConfigRequest: {
       cpuLimit?: string;
       memoryLimit?: string;
@@ -550,6 +737,17 @@ export interface components {
       memoryLimit?: string;
       /** Format: date-time */
       updatedAt?: string;
+    };
+    AdminUpdateChallengeRequestDto: {
+      title: string;
+      shortDescription?: string;
+      description?: string;
+      /** @enum {string} */
+      status: "DRAFT" | "PRIVATE" | "PUBLIC";
+      /** @enum {string} */
+      difficulty: "BEGINNER" | "EASY" | "MEDIUM" | "HARD" | "EXPERT";
+      /** Format: int32 */
+      maxScore?: number;
     };
     CreateCourseInstructorRequestDto: {
       /** Format: uuid */
@@ -601,6 +799,30 @@ export interface components {
       isPublished?: boolean;
       isPrivate?: boolean;
     };
+    ChallengeStudentDto: {
+      /** Format: uuid */
+      id?: string;
+      title?: string;
+      shortDescription?: string;
+      description?: string;
+      /** @enum {string} */
+      status?: "DRAFT" | "PRIVATE" | "PUBLIC";
+      /** @enum {string} */
+      difficulty?: "BEGINNER" | "EASY" | "MEDIUM" | "HARD" | "EXPERT";
+      /** Format: int32 */
+      maxScore?: number;
+      creator?: components["schemas"]["ChallengeCreatorResponseDto"];
+      subTasks?: components["schemas"]["SubTaskStudentDto"][];
+      /** Format: int32 */
+      solvedSubTaskCount?: number;
+      /** Format: int32 */
+      totalSubTaskCount?: number;
+      /** Format: date-time */
+      createdAt?: string;
+      /** Format: date-time */
+      updatedAt?: string;
+      isSolved?: boolean;
+    };
     PublicCourseDetailResponseDto: {
       /** Format: uuid */
       id?: string;
@@ -614,7 +836,7 @@ export interface components {
       inviteCode?: string;
       courseInstructors?: components["schemas"]["CourseDetailInstructorResponseDto"][];
       participants?: components["schemas"]["CourseParticipantResponseDto"][];
-      courseChallenges?: components["schemas"]["ChallengeDetailResponseDto"][];
+      courseChallenges?: components["schemas"]["ChallengeStudentDto"][];
       /** Format: date-time */
       createdAt?: string;
       /** Format: date-time */
@@ -623,6 +845,16 @@ export interface components {
       published?: boolean;
       isEnrolled?: boolean;
       isPublished?: boolean;
+    };
+    SubTaskStudentDto: {
+      /** Format: uuid */
+      id?: string;
+      title?: string;
+      description?: string;
+      /** Format: int32 */
+      orderIndex?: number;
+      solvedFlag?: string;
+      isSolved?: boolean;
     };
     JoinByInviteCodeRequestDto: {
       code: string;
@@ -659,6 +891,17 @@ export interface components {
       /** Format: date-time */
       updatedAt?: string;
     };
+    SubTaskSubmissionRequestDto: {
+      flag: string;
+    };
+    SubTaskSubmissionResponseDto: {
+      /** Format: int32 */
+      solvedSubTaskCount?: number;
+      /** Format: int32 */
+      totalSubTaskCount?: number;
+      isCorrect?: boolean;
+      isChallengeSolved?: boolean;
+    };
     PodCreationRequest: {
       containerName?: string;
       image: string;
@@ -673,6 +916,9 @@ export interface components {
       appUrl?: string;
       terminalUrl?: string;
       terminalPassword?: string;
+    };
+    AdminTopicRequest: {
+      value: string;
     };
     Pageable: {
       /** Format: int32 */
@@ -691,10 +937,10 @@ export interface components {
       roles?: ("ROLE_ADMINISTRATOR" | "ROLE_INSTRUCTOR" | "ROLE_STUDENT")[];
     };
     PageListInstructorUserResponseDto: {
-      /** Format: int32 */
-      totalPages?: number;
       /** Format: int64 */
       totalElements?: number;
+      /** Format: int32 */
+      totalPages?: number;
       /** Format: int32 */
       size?: number;
       content?: components["schemas"]["ListInstructorUserResponseDto"][];
@@ -712,11 +958,11 @@ export interface components {
       /** Format: int64 */
       offset?: number;
       sort?: components["schemas"]["SortObject"];
-      /** Format: int32 */
-      pageSize?: number;
+      paged?: boolean;
       /** Format: int32 */
       pageNumber?: number;
-      paged?: boolean;
+      /** Format: int32 */
+      pageSize?: number;
       unpaged?: boolean;
     };
     SortObject: {
@@ -747,10 +993,10 @@ export interface components {
       isPrivate?: boolean;
     };
     PageListCourseResponseDto: {
-      /** Format: int32 */
-      totalPages?: number;
       /** Format: int64 */
       totalElements?: number;
+      /** Format: int32 */
+      totalPages?: number;
       /** Format: int32 */
       size?: number;
       content?: components["schemas"]["ListCourseResponseDto"][];
@@ -783,10 +1029,10 @@ export interface components {
       updatedAt?: string;
     };
     PageListChallengeResponseDto: {
-      /** Format: int32 */
-      totalPages?: number;
       /** Format: int64 */
       totalElements?: number;
+      /** Format: int32 */
+      totalPages?: number;
       /** Format: int32 */
       size?: number;
       content?: components["schemas"]["ListChallengeResponseDto"][];
@@ -803,6 +1049,86 @@ export interface components {
     VisibilityImpactResponseDto: {
       /** Format: int32 */
       affectedCourseCount?: number;
+    };
+    AdminCourseListItemDto: {
+      /** Format: uuid */
+      id?: string;
+      title?: string;
+      description?: string;
+      shortDescription?: string;
+      /** Format: date-time */
+      createdAt?: string;
+      /** Format: date-time */
+      updatedAt?: string;
+      topic?: string;
+      imageUrl?: string;
+      /** Format: uuid */
+      ownerId?: string;
+      ownerName?: string;
+      ownerUsername?: string;
+      private?: boolean;
+      published?: boolean;
+      isPublished?: boolean;
+      isPrivate?: boolean;
+    };
+    PageAdminCourseListItemDto: {
+      /** Format: int64 */
+      totalElements?: number;
+      /** Format: int32 */
+      totalPages?: number;
+      /** Format: int32 */
+      size?: number;
+      content?: components["schemas"]["AdminCourseListItemDto"][];
+      /** Format: int32 */
+      number?: number;
+      sort?: components["schemas"]["SortObject"];
+      first?: boolean;
+      last?: boolean;
+      /** Format: int32 */
+      numberOfElements?: number;
+      pageable?: components["schemas"]["PageableObject"];
+      empty?: boolean;
+    };
+    AdminChallengeListItemDto: {
+      /** Format: uuid */
+      id?: string;
+      title?: string;
+      shortDescription?: string;
+      description?: string;
+      /** @enum {string} */
+      status?: "DRAFT" | "PRIVATE" | "PUBLIC";
+      /** @enum {string} */
+      difficulty?: "BEGINNER" | "EASY" | "MEDIUM" | "HARD" | "EXPERT";
+      /** Format: int32 */
+      maxScore?: number;
+      /** Format: int64 */
+      courseCount?: number;
+      /** Format: date-time */
+      createdAt?: string;
+      /** Format: date-time */
+      updatedAt?: string;
+      /** Format: uuid */
+      creatorId?: string;
+      creatorName?: string;
+      creatorUsername?: string;
+    };
+    PageAdminChallengeListItemDto: {
+      /** Format: int64 */
+      totalElements?: number;
+      /** Format: int32 */
+      totalPages?: number;
+      /** Format: int32 */
+      size?: number;
+      content?: components["schemas"]["AdminChallengeListItemDto"][];
+      /** Format: int32 */
+      number?: number;
+      sort?: components["schemas"]["SortObject"];
+      first?: boolean;
+      last?: boolean;
+      /** Format: int32 */
+      numberOfElements?: number;
+      pageable?: components["schemas"]["PageableObject"];
+      empty?: boolean;
     };
   };
   responses: never;
@@ -1101,6 +1427,50 @@ export interface operations {
       };
     };
   };
+  updateCourse_1: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AdminUpdateCourseRequestDto"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  deleteCourse_1: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   getAdminConfig: {
     parameters: {
       query?: never;
@@ -1188,6 +1558,50 @@ export interface operations {
             [key: string]: string;
           };
         };
+      };
+    };
+  };
+  updateChallenge_1: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AdminUpdateChallengeRequestDto"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  deleteChallenge_1: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };
@@ -1481,6 +1895,69 @@ export interface operations {
       };
     };
   };
+  submitSubTaskFlag: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        challengeId: string;
+        subTaskId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SubTaskSubmissionRequestDto"];
+      };
+    };
+    responses: {
+      /** @description Submission processed */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["SubTaskSubmissionResponseDto"];
+        };
+      };
+      /** @description Invalid flag format */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description User not enrolled in a course containing this challenge */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Challenge or sub-task not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Sub-task already solved */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+    };
+  };
   createPod: {
     parameters: {
       query?: never;
@@ -1501,6 +1978,52 @@ export interface operations {
         };
         content: {
           "*/*": components["schemas"]["PodCreationResponse"];
+        };
+      };
+    };
+  };
+  listTopics: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": string[];
+        };
+      };
+    };
+  };
+  addTopic: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AdminTopicRequest"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": {
+            [key: string]: string;
+          };
         };
       };
     };
@@ -1551,6 +2074,26 @@ export interface operations {
       };
     };
   };
+  listCourseTopics: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": string[];
+        };
+      };
+    };
+  };
   listEnrollments: {
     parameters: {
       query: {
@@ -1586,6 +2129,7 @@ export interface operations {
     parameters: {
       query: {
         query?: string;
+        topic?: string;
         pageable: components["schemas"]["Pageable"];
       };
       header?: never;
@@ -1696,6 +2240,48 @@ export interface operations {
       };
     };
   };
+  getChallengeForPlay: {
+    parameters: {
+      query: {
+        courseId: string;
+      };
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Challenge retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ChallengeStudentDto"];
+        };
+      };
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Challenge not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+    };
+  };
   searchChallenges: {
     parameters: {
       query: {
@@ -1719,6 +2305,91 @@ export interface operations {
       };
     };
   };
+  listCourses_1: {
+    parameters: {
+      query: {
+        q?: string;
+        pageable: components["schemas"]["Pageable"];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["PageAdminCourseListItemDto"];
+        };
+      };
+    };
+  };
+  listChallenges_1: {
+    parameters: {
+      query: {
+        q?: string;
+        pageable: components["schemas"]["Pageable"];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["PageAdminChallengeListItemDto"];
+        };
+      };
+    };
+  };
+  removeParticipant: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+        participantId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Participant removed successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Course or participant not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+    };
+  };
   deletePod: {
     parameters: {
       query?: never;
@@ -1736,6 +2407,30 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+    };
+  };
+  deleteTopic: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        value: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": {
+            [key: string]: string;
+          };
+        };
       };
     };
   };

--- a/frontend/src/shared/types/course.ts
+++ b/frontend/src/shared/types/course.ts
@@ -1,4 +1,9 @@
-import type { ChallengeDetailResponseDto } from "@/src/features/course/actions/challenges";
+import type { components } from "@/src/shared/lib/api/schema";
+
+export type SubTaskStudentDto = components["schemas"]["SubTaskStudentDto"];
+export type ChallengeStudentDto = components["schemas"]["ChallengeStudentDto"];
+export type SubTaskSubmissionRequestDto = components["schemas"]["SubTaskSubmissionRequestDto"];
+export type SubTaskSubmissionResponseDto = components["schemas"]["SubTaskSubmissionResponseDto"];
 
 export type InstructorRoleEnum = "OWNER" | "COLLABORATOR";
 export type PlatformRole = "ROLE_ADMINISTRATOR" | "ROLE_INSTRUCTOR" | "ROLE_STUDENT";
@@ -129,7 +134,7 @@ export interface PublicCourseDetailResponseDto {
   topic?: string | null;
   courseInstructors: CourseInstructorResponseDto[];
   participants: null;
-  courseChallenges: ChallengeDetailResponseDto[];
+  courseChallenges: ChallengeStudentDto[];
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
Adds a student-facing play view for challenges, including per-user progress tracking and a submit endpoint for sub-task flags.

Backend
- New SubTaskCompletion entity + repository, persisting solved sub-tasks with a unique (user, sub-task) constraint.
- New student-facing DTOs (ChallengeStudentDto, SubTaskStudentDto) that omit the plaintext flag, exposing it only back to the user who solved the sub-task via solvedFlag.
- New endpoints:
  - GET  /api/v1/challenges/{id}/play?courseId=... returns the challenge in student form with per-user progress.
  - POST /api/v1/challenges/{challengeId}/subtasks/{subTaskId}/submit validates the submitted flag (case-sensitive), persists the completion, and rejects already-solved sub-tasks (HTTP 409).
- PublicCourseDetailResponseDto.courseChallenges now uses ChallengeStudentDto so flags are never leaked on the public catalog.
- Per-student progress (solvedSubTaskCount, totalSubTaskCount, isSolved) is populated in a single batched query.
- New exceptions SubTaskNotFoundException and SubTaskAlreadySolvedException registered in GlobalExceptionHandler.

Frontend
- New route /dashboard/courses/[id]/challenges/[cid]/play with a split-pane layout: challenge description and sub-task stepper on the left, lab environment placeholder (YouTube embed with fullscreen toggle) on the right.
- Sub-task flag submission with Mantine notifications for success/error, input locking on solved sub-tasks, and re-display of previously submitted flags via solvedFlag from the backend.
- Course details page now shows a sub-task progress accordion with expandable sub-task lists, per-challenge progress badges, and a "Start Next Challenge" CTA.
- Dashboard "Currently running Challenges" block links into the play view via the same accordion component.
- All new server actions use the typed openapi-fetch client through the withActionResult helpers — no fetchBackend in the new code.
- Mantine Notifications provider added to the root layout (was missing).