### PR TITLE
feat: add configurable MC attempts mode per course (ONCE vs UNLIMITED)

### DIFF
--- a/backend/src/main/java/com/pm4/istp/course/controllers/ChallengeController.java
+++ b/backend/src/main/java/com/pm4/istp/course/controllers/ChallengeController.java
@@ -370,7 +370,7 @@ public class ChallengeController {
     UUID userId = parseUserId(jwt);
     ChoiceSubmissionResponseDto response =
         challengeService.submitSubTaskChoice(
-            userId, challengeId, subTaskId, request.getSelectedOptionId());
+            userId, request.getCourseId(), challengeId, subTaskId, request.getSelectedOptionId());
     return ResponseEntity.ok(response);
   }
 

--- a/backend/src/main/java/com/pm4/istp/course/db/CreateCourseRequest.java
+++ b/backend/src/main/java/com/pm4/istp/course/db/CreateCourseRequest.java
@@ -1,5 +1,6 @@
 package com.pm4.istp.course.db;
 
+import com.pm4.istp.course.db.entities.McAttemptsMode;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -17,4 +18,5 @@ public class CreateCourseRequest {
   private String imageUrl;
   private String topic;
   private List<CreateCourseInstructorRequest> instructors;
+  private McAttemptsMode mcAttemptsMode = McAttemptsMode.UNLIMITED;
 }

--- a/backend/src/main/java/com/pm4/istp/course/db/UpdateCourseRequest.java
+++ b/backend/src/main/java/com/pm4/istp/course/db/UpdateCourseRequest.java
@@ -1,5 +1,6 @@
 package com.pm4.istp.course.db;
 
+import com.pm4.istp.course.db.entities.McAttemptsMode;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -17,4 +18,5 @@ public class UpdateCourseRequest {
   private String imageUrl;
   private String topic;
   private List<UpdateCourseInstructorRequest> instructors;
+  private McAttemptsMode mcAttemptsMode = McAttemptsMode.UNLIMITED;
 }

--- a/backend/src/main/java/com/pm4/istp/course/db/entities/Course.java
+++ b/backend/src/main/java/com/pm4/istp/course/db/entities/Course.java
@@ -92,8 +92,8 @@ public class Course {
   }
 
   /**
-   * Controls how many attempts students get for MULTIPLE_CHOICE sub-tasks in this course.
-   * Defaults to UNLIMITED (self-learning). Set to ONCE for graded / Praktikum courses.
+   * Controls how many attempts students get for MULTIPLE_CHOICE sub-tasks in this course. Defaults
+   * to UNLIMITED (self-learning). Set to ONCE for graded / Praktikum courses.
    */
   @Column(
       name = "mc_attempts_mode",

--- a/backend/src/main/java/com/pm4/istp/course/db/entities/Course.java
+++ b/backend/src/main/java/com/pm4/istp/course/db/entities/Course.java
@@ -91,6 +91,17 @@ public class Course {
     courseChallenge.setCourse(null);
   }
 
+  /**
+   * Controls how many attempts students get for MULTIPLE_CHOICE sub-tasks in this course.
+   * Defaults to UNLIMITED (self-learning). Set to ONCE for graded / Praktikum courses.
+   */
+  @Column(
+      name = "mc_attempts_mode",
+      nullable = false,
+      columnDefinition = "VARCHAR(20) NOT NULL DEFAULT 'UNLIMITED'")
+  @Enumerated(EnumType.STRING)
+  private McAttemptsMode mcAttemptsMode = McAttemptsMode.UNLIMITED;
+
   @Column(name = "badge_primary_color", nullable = true, length = 7)
   private String badgePrimaryColor;
 

--- a/backend/src/main/java/com/pm4/istp/course/db/entities/McAttemptsMode.java
+++ b/backend/src/main/java/com/pm4/istp/course/db/entities/McAttemptsMode.java
@@ -1,0 +1,16 @@
+package com.pm4.istp.course.db.entities;
+
+/**
+ * Controls how many attempts a student gets for MULTIPLE_CHOICE sub-tasks in a course.
+ *
+ * <ul>
+ *   <li>{@link #ONCE} – the student may pick exactly one option; the sub-task is marked
+ *       completed regardless of whether the answer is correct (graded / Praktikum mode).
+ *   <li>{@link #UNLIMITED} – the student may keep trying until they choose the correct option;
+ *       the sub-task is only marked completed on a correct answer (self-learning mode).
+ * </ul>
+ */
+public enum McAttemptsMode {
+  ONCE,
+  UNLIMITED
+}

--- a/backend/src/main/java/com/pm4/istp/course/db/entities/McAttemptsMode.java
+++ b/backend/src/main/java/com/pm4/istp/course/db/entities/McAttemptsMode.java
@@ -4,10 +4,10 @@ package com.pm4.istp.course.db.entities;
  * Controls how many attempts a student gets for MULTIPLE_CHOICE sub-tasks in a course.
  *
  * <ul>
- *   <li>{@link #ONCE} – the student may pick exactly one option; the sub-task is marked
- *       completed regardless of whether the answer is correct (graded / Praktikum mode).
- *   <li>{@link #UNLIMITED} – the student may keep trying until they choose the correct option;
- *       the sub-task is only marked completed on a correct answer (self-learning mode).
+ *   <li>{@link #ONCE} – the student may pick exactly one option; the sub-task is marked completed
+ *       regardless of whether the answer is correct (graded / Praktikum mode).
+ *   <li>{@link #UNLIMITED} – the student may keep trying until they choose the correct option; the
+ *       sub-task is only marked completed on a correct answer (self-learning mode).
  * </ul>
  */
 public enum McAttemptsMode {

--- a/backend/src/main/java/com/pm4/istp/course/dto/ChallengeStudentDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/ChallengeStudentDto.java
@@ -37,4 +37,10 @@ public class ChallengeStudentDto {
 
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
+
+  /**
+   * MC attempt mode inherited from the course context. "ONCE" = one attempt regardless of
+   * correctness; "UNLIMITED" = retry until correct. Only populated on the play view.
+   */
+  private String mcAttemptsMode;
 }

--- a/backend/src/main/java/com/pm4/istp/course/dto/ChoiceSubmissionRequestDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/ChoiceSubmissionRequestDto.java
@@ -12,4 +12,8 @@ import lombok.NoArgsConstructor;
 public class ChoiceSubmissionRequestDto {
   @NotNull(message = "selectedOptionId is required")
   private UUID selectedOptionId;
+
+  /** The course context from which the student is solving this sub-task. Required for MC mode. */
+  @NotNull(message = "courseId is required")
+  private UUID courseId;
 }

--- a/backend/src/main/java/com/pm4/istp/course/dto/CourseDetailResponseDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/CourseDetailResponseDto.java
@@ -37,4 +37,7 @@ public class CourseDetailResponseDto {
   private List<CourseChallengeResponseDto> courseChallenges;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
+
+  /** "ONCE" or "UNLIMITED" – controls MC attempt behaviour for students. */
+  private String mcAttemptsMode;
 }

--- a/backend/src/main/java/com/pm4/istp/course/dto/CreateCourseRequestDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/CreateCourseRequestDto.java
@@ -38,4 +38,10 @@ public class CreateCourseRequestDto {
 
   @NotNull(message = "Instructor information is required")
   private List<CreateCourseInstructorRequestDto> instructors;
+
+  /**
+   * How many MC attempts students get. "ONCE" = 1 attempt (graded); "UNLIMITED" = retry until
+   * correct (self-learning). Defaults to "UNLIMITED".
+   */
+  private String mcAttemptsMode = "UNLIMITED";
 }

--- a/backend/src/main/java/com/pm4/istp/course/dto/UpdateCourseRequestDto.java
+++ b/backend/src/main/java/com/pm4/istp/course/dto/UpdateCourseRequestDto.java
@@ -38,4 +38,10 @@ public class UpdateCourseRequestDto {
 
   @NotNull(message = "Instructor information is required")
   private List<UpdateCourseInstructorRequestDto> instructors;
+
+  /**
+   * How many MC attempts students get. "ONCE" = 1 attempt (graded); "UNLIMITED" = retry until
+   * correct (self-learning). Defaults to "UNLIMITED".
+   */
+  private String mcAttemptsMode = "UNLIMITED";
 }

--- a/backend/src/main/java/com/pm4/istp/course/services/ChallengeService.java
+++ b/backend/src/main/java/com/pm4/istp/course/services/ChallengeService.java
@@ -45,6 +45,7 @@ public interface ChallengeService {
    * Submits a multiple-choice option for a sub-task.
    *
    * <p>Behaviour depends on the course's {@code mcAttemptsMode}:
+   *
    * <ul>
    *   <li>{@code ONCE} – the submission is recorded and the sub-task is marked completed regardless
    *       of correctness. Points are awarded only when the answer is correct.

--- a/backend/src/main/java/com/pm4/istp/course/services/ChallengeService.java
+++ b/backend/src/main/java/com/pm4/istp/course/services/ChallengeService.java
@@ -42,11 +42,18 @@ public interface ChallengeService {
       UUID userId, UUID challengeId, UUID subTaskId, String flag);
 
   /**
-   * Submits a multiple-choice option for a sub-task. Automatically awards points when correct. A
-   * student may only submit once; re-submission returns the existing result.
+   * Submits a multiple-choice option for a sub-task.
+   *
+   * <p>Behaviour depends on the course's {@code mcAttemptsMode}:
+   * <ul>
+   *   <li>{@code ONCE} – the submission is recorded and the sub-task is marked completed regardless
+   *       of correctness. Points are awarded only when the answer is correct.
+   *   <li>{@code UNLIMITED} – wrong answers are NOT persisted, so the student can retry. The
+   *       sub-task is marked completed only on a correct answer.
+   * </ul>
    */
   ChoiceSubmissionResponseDto submitSubTaskChoice(
-      UUID userId, UUID challengeId, UUID subTaskId, UUID selectedOptionId);
+      UUID userId, UUID courseId, UUID challengeId, UUID subTaskId, UUID selectedOptionId);
 
   /**
    * Completes a theory sub-task (FLAG type with no flag set) without requiring a flag submission.

--- a/backend/src/main/java/com/pm4/istp/course/services/impl/ChallengeServiceImpl.java
+++ b/backend/src/main/java/com/pm4/istp/course/services/impl/ChallengeServiceImpl.java
@@ -21,10 +21,10 @@ import com.pm4.istp.course.dto.SubTaskStudentDto;
 import com.pm4.istp.course.dto.SubTaskSubmissionResponseDto;
 import com.pm4.istp.course.exceptions.ChallengeAccessDeniedException;
 import com.pm4.istp.course.exceptions.ChallengeNotFoundException;
+import com.pm4.istp.course.exceptions.CourseNotFoundException;
 import com.pm4.istp.course.exceptions.SubTaskAlreadySolvedException;
 import com.pm4.istp.course.exceptions.SubTaskNotFoundException;
 import com.pm4.istp.course.mappers.ChallengeMapper;
-import com.pm4.istp.course.exceptions.CourseNotFoundException;
 import com.pm4.istp.course.repositories.ChallengeRepository;
 import com.pm4.istp.course.repositories.CourseChallengeRepository;
 import com.pm4.istp.course.repositories.CourseEnrollmentRepository;
@@ -541,8 +541,8 @@ public class ChallengeServiceImpl implements ChallengeService {
         studentOptionSubmissionRepository.saveAndFlush(submission);
       } catch (DataIntegrityViolationException ex) {
         // Concurrent submission — return current state
-        return buildChoiceResponse(correct, userId, subTask.getChallenge(), challengeId,
-            correct ? null : subTask);
+        return buildChoiceResponse(
+            correct, userId, subTask.getChallenge(), challengeId, correct ? null : subTask);
       }
 
       // Mark as completed regardless of correctness (ONCE = attempted = done)
@@ -559,8 +559,8 @@ public class ChallengeServiceImpl implements ChallengeService {
       }
 
       ChoiceSubmissionResponseDto response =
-          buildChoiceResponse(correct, userId, subTask.getChallenge(), challengeId,
-              correct ? null : subTask);
+          buildChoiceResponse(
+              correct, userId, subTask.getChallenge(), challengeId, correct ? null : subTask);
       if (response.isChallengeSolved()) {
         badgeService.tryAwardBadgesForChallenge(userId, challengeId);
       }

--- a/backend/src/main/java/com/pm4/istp/course/services/impl/ChallengeServiceImpl.java
+++ b/backend/src/main/java/com/pm4/istp/course/services/impl/ChallengeServiceImpl.java
@@ -7,6 +7,8 @@ import com.pm4.istp.course.db.SubTaskRequest;
 import com.pm4.istp.course.db.UpdateChallengeRequest;
 import com.pm4.istp.course.db.entities.Challenge;
 import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
+import com.pm4.istp.course.db.entities.Course;
+import com.pm4.istp.course.db.entities.McAttemptsMode;
 import com.pm4.istp.course.db.entities.StudentOptionSubmission;
 import com.pm4.istp.course.db.entities.SubTask;
 import com.pm4.istp.course.db.entities.SubTaskCompletion;
@@ -22,9 +24,11 @@ import com.pm4.istp.course.exceptions.ChallengeNotFoundException;
 import com.pm4.istp.course.exceptions.SubTaskAlreadySolvedException;
 import com.pm4.istp.course.exceptions.SubTaskNotFoundException;
 import com.pm4.istp.course.mappers.ChallengeMapper;
+import com.pm4.istp.course.exceptions.CourseNotFoundException;
 import com.pm4.istp.course.repositories.ChallengeRepository;
 import com.pm4.istp.course.repositories.CourseChallengeRepository;
 import com.pm4.istp.course.repositories.CourseEnrollmentRepository;
+import com.pm4.istp.course.repositories.CourseRepository;
 import com.pm4.istp.course.repositories.StudentOptionSubmissionRepository;
 import com.pm4.istp.course.repositories.SubTaskCompletionRepository;
 import com.pm4.istp.course.repositories.SubTaskOptionRepository;
@@ -58,9 +62,12 @@ public class ChallengeServiceImpl implements ChallengeService {
   private static final String CHALLENGE_NOT_FOUND_MSG = "Challenge with ID '%s' not found";
   private static final String SUB_TASK_NOT_FOUND_MSG = "Sub-task with ID '%s' not found";
 
+  private static final String COURSE_NOT_FOUND_MSG = "Course with ID '%s' not found";
+
   private final UserRepository userRepository;
   private final ChallengeRepository challengeRepository;
   private final CourseChallengeRepository courseChallengeRepository;
+  private final CourseRepository courseRepository;
   private final SubTaskRepository subTaskRepository;
   private final SubTaskOptionRepository subTaskOptionRepository;
   private final SubTaskCompletionRepository subTaskCompletionRepository;
@@ -381,6 +388,17 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     ChallengeStudentDto dto = challengeMapper.toStudentDto(challenge);
     populateStudentProgress(dto, userId, challenge);
+
+    // Expose the course's MC attempt mode so the frontend can render the UI correctly
+    Course course =
+        courseRepository
+            .findById(courseId)
+            .orElseThrow(
+                () -> new CourseNotFoundException(String.format(COURSE_NOT_FOUND_MSG, courseId)));
+    McAttemptsMode mode =
+        course.getMcAttemptsMode() != null ? course.getMcAttemptsMode() : McAttemptsMode.UNLIMITED;
+    dto.setMcAttemptsMode(mode.name());
+
     return dto;
   }
 
@@ -452,7 +470,7 @@ public class ChallengeServiceImpl implements ChallengeService {
   @Override
   @Transactional
   public ChoiceSubmissionResponseDto submitSubTaskChoice(
-      UUID userId, UUID challengeId, UUID subTaskId, UUID selectedOptionId) {
+      UUID userId, UUID courseId, UUID challengeId, UUID subTaskId, UUID selectedOptionId) {
     User user =
         userRepository
             .findByIdAndDeletedAtIsNull(userId)
@@ -473,7 +491,16 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     verifyEnrolledInChallengeCourse(userId, subTask.getChallenge());
 
-    // Return existing submission if already answered
+    // Determine which attempt mode this course uses
+    Course course =
+        courseRepository
+            .findById(courseId)
+            .orElseThrow(
+                () -> new CourseNotFoundException(String.format(COURSE_NOT_FOUND_MSG, courseId)));
+    McAttemptsMode mode =
+        course.getMcAttemptsMode() != null ? course.getMcAttemptsMode() : McAttemptsMode.UNLIMITED;
+
+    // Return existing submission if already saved (applies to ONCE mode and correct UNLIMITED)
     Optional<StudentOptionSubmission> existing =
         studentOptionSubmissionRepository.findByUserIdAndSubTaskId(userId, subTaskId);
     if (existing.isPresent()) {
@@ -499,42 +526,88 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     boolean correct = selectedOption.isCorrect();
 
-    StudentOptionSubmission submission = new StudentOptionSubmission();
-    submission.setUser(user);
-    submission.setSubTask(subTask);
-    submission.setSelectedOption(selectedOption);
-    submission.setCorrect(correct);
-    submission.setSubmittedAt(LocalDateTime.now());
-    try {
-      studentOptionSubmissionRepository.saveAndFlush(submission);
-    } catch (DataIntegrityViolationException ex) {
-      // Concurrent submission — just return current state
-      return buildChoiceResponse(
-          correct, userId, subTask.getChallenge(), challengeId, correct ? null : subTask);
-    }
-
-    // Award completion when correct (reuse the same SubTaskCompletion mechanism)
-    if (correct && !subTaskCompletionRepository.existsByUserIdAndSubTaskId(userId, subTaskId)) {
-      SubTaskCompletion completion = new SubTaskCompletion();
-      completion.setUser(user);
-      completion.setSubTask(subTask);
-      completion.setSolvedAt(LocalDateTime.now());
+    if (mode == McAttemptsMode.ONCE) {
+      // -----------------------------------------------------------------------
+      // ONCE mode: always persist the submission (even if wrong) and always mark
+      // the sub-task as completed so progress is counted.
+      // -----------------------------------------------------------------------
+      StudentOptionSubmission submission = new StudentOptionSubmission();
+      submission.setUser(user);
+      submission.setSubTask(subTask);
+      submission.setSelectedOption(selectedOption);
+      submission.setCorrect(correct);
+      submission.setSubmittedAt(LocalDateTime.now());
       try {
-        subTaskCompletionRepository.saveAndFlush(completion);
-      } catch (DataIntegrityViolationException ignored) {
-        // Already recorded by a concurrent request
+        studentOptionSubmissionRepository.saveAndFlush(submission);
+      } catch (DataIntegrityViolationException ex) {
+        // Concurrent submission — return current state
+        return buildChoiceResponse(correct, userId, subTask.getChallenge(), challengeId,
+            correct ? null : subTask);
       }
+
+      // Mark as completed regardless of correctness (ONCE = attempted = done)
+      if (!subTaskCompletionRepository.existsByUserIdAndSubTaskId(userId, subTaskId)) {
+        SubTaskCompletion completion = new SubTaskCompletion();
+        completion.setUser(user);
+        completion.setSubTask(subTask);
+        completion.setSolvedAt(LocalDateTime.now());
+        try {
+          subTaskCompletionRepository.saveAndFlush(completion);
+        } catch (DataIntegrityViolationException ignored) {
+          // Already recorded by concurrent request
+        }
+      }
+
+      ChoiceSubmissionResponseDto response =
+          buildChoiceResponse(correct, userId, subTask.getChallenge(), challengeId,
+              correct ? null : subTask);
+      if (response.isChallengeSolved()) {
+        badgeService.tryAwardBadgesForChallenge(userId, challengeId);
+      }
+      return response;
+
+    } else {
+      // -----------------------------------------------------------------------
+      // UNLIMITED mode: only persist and complete when the answer is correct.
+      // Wrong answers are NOT saved, so the student can retry.
+      // -----------------------------------------------------------------------
+      if (!correct) {
+        // Return temporary response without persisting anything
+        return buildChoiceResponse(false, userId, subTask.getChallenge(), challengeId, subTask);
+      }
+
+      // Correct answer — persist submission and completion
+      StudentOptionSubmission submission = new StudentOptionSubmission();
+      submission.setUser(user);
+      submission.setSubTask(subTask);
+      submission.setSelectedOption(selectedOption);
+      submission.setCorrect(true);
+      submission.setSubmittedAt(LocalDateTime.now());
+      try {
+        studentOptionSubmissionRepository.saveAndFlush(submission);
+      } catch (DataIntegrityViolationException ex) {
+        return buildChoiceResponse(true, userId, subTask.getChallenge(), challengeId, null);
+      }
+
+      if (!subTaskCompletionRepository.existsByUserIdAndSubTaskId(userId, subTaskId)) {
+        SubTaskCompletion completion = new SubTaskCompletion();
+        completion.setUser(user);
+        completion.setSubTask(subTask);
+        completion.setSolvedAt(LocalDateTime.now());
+        try {
+          subTaskCompletionRepository.saveAndFlush(completion);
+        } catch (DataIntegrityViolationException ignored) {
+          // Already recorded by concurrent request
+        }
+      }
+
+      ChoiceSubmissionResponseDto response =
+          buildChoiceResponse(true, userId, subTask.getChallenge(), challengeId, null);
+      if (response.isChallengeSolved()) {
+        badgeService.tryAwardBadgesForChallenge(userId, challengeId);
+      }
+      return response;
     }
-
-    ChoiceSubmissionResponseDto response =
-        buildChoiceResponse(
-            correct, userId, subTask.getChallenge(), challengeId, correct ? null : subTask);
-
-    if (correct && response.isChallengeSolved()) {
-      badgeService.tryAwardBadgesForChallenge(userId, challengeId);
-    }
-
-    return response;
   }
 
   private ChoiceSubmissionResponseDto buildChoiceResponse(

--- a/backend/src/main/java/com/pm4/istp/course/services/impl/CourseServiceImpl.java
+++ b/backend/src/main/java/com/pm4/istp/course/services/impl/CourseServiceImpl.java
@@ -11,6 +11,7 @@ import com.pm4.istp.course.db.entities.Course;
 import com.pm4.istp.course.db.entities.CourseChallenge;
 import com.pm4.istp.course.db.entities.CourseEnrollment;
 import com.pm4.istp.course.db.entities.CourseInstructor;
+import com.pm4.istp.course.db.entities.McAttemptsMode;
 import com.pm4.istp.course.dto.CourseChallengeDeadlineDto;
 import com.pm4.istp.course.dto.CourseChallengeItemDto;
 import com.pm4.istp.course.dto.CourseChallengeResponseDto;
@@ -89,6 +90,8 @@ public class CourseServiceImpl implements CourseService {
     validateVisibilityState(course.isPublished(), course.isPrivate());
     courseToCreate.setImageUrl(course.getImageUrl());
     courseToCreate.setTopic(courseTopicService.normalizeAndValidate(course.getTopic()));
+    courseToCreate.setMcAttemptsMode(
+        course.getMcAttemptsMode() != null ? course.getMcAttemptsMode() : McAttemptsMode.UNLIMITED);
 
     // Owner = the user making the request
     CourseInstructor owner = new CourseInstructor();
@@ -220,6 +223,10 @@ public class CourseServiceImpl implements CourseService {
     }
     course.setPublished(willBePublished);
     course.setPrivate(willBePrivate);
+    course.setMcAttemptsMode(
+        request.getMcAttemptsMode() != null
+            ? request.getMcAttemptsMode()
+            : McAttemptsMode.UNLIMITED);
 
     // Diff instructor list: preserve OWNER, update COLLABORATORs
     Set<UUID> requestedInstructorIds =

--- a/backend/src/test/java/com/pm4/istp/course/ChallengeServiceImplTest.java
+++ b/backend/src/test/java/com/pm4/istp/course/ChallengeServiceImplTest.java
@@ -33,6 +33,7 @@ import com.pm4.istp.course.db.entities.ChallengeDifficultyEnum;
 import com.pm4.istp.course.db.entities.ChallengeStatusEnum;
 import com.pm4.istp.course.db.entities.Course;
 import com.pm4.istp.course.db.entities.CourseChallenge;
+import com.pm4.istp.course.db.entities.McAttemptsMode;
 import com.pm4.istp.course.db.entities.SubTask;
 import com.pm4.istp.course.db.entities.SubTaskType;
 import com.pm4.istp.course.db.entities.SubTaskCompletion;
@@ -47,7 +48,10 @@ import com.pm4.istp.course.mappers.ChallengeMapper;
 import com.pm4.istp.course.repositories.ChallengeRepository;
 import com.pm4.istp.course.repositories.CourseChallengeRepository;
 import com.pm4.istp.course.repositories.CourseEnrollmentRepository;
+import com.pm4.istp.course.repositories.CourseRepository;
+import com.pm4.istp.course.repositories.StudentOptionSubmissionRepository;
 import com.pm4.istp.course.repositories.SubTaskCompletionRepository;
+import com.pm4.istp.course.repositories.SubTaskOptionRepository;
 import com.pm4.istp.course.repositories.SubTaskRepository;
 import com.pm4.istp.course.services.DockerImageAvailabilityService;
 import com.pm4.istp.course.services.impl.ChallengeServiceImpl;
@@ -64,8 +68,11 @@ class ChallengeServiceImplTest {
   @Mock private UserRepository userRepository;
   @Mock private ChallengeRepository challengeRepository;
   @Mock private CourseChallengeRepository courseChallengeRepository;
+  @Mock private CourseRepository courseRepository;
   @Mock private SubTaskRepository subTaskRepository;
+  @Mock private SubTaskOptionRepository subTaskOptionRepository;
   @Mock private SubTaskCompletionRepository subTaskCompletionRepository;
+  @Mock private StudentOptionSubmissionRepository studentOptionSubmissionRepository;
   @Mock private CourseEnrollmentRepository courseEnrollmentRepository;
   @Mock private ChallengeMapper challengeMapper;
   @Mock private DockerImageAvailabilityService dockerImageAvailabilityService;
@@ -750,9 +757,16 @@ class ChallengeServiceImplTest {
     dto.setId(challengeId);
     when(challengeMapper.toStudentDto(challenge)).thenReturn(dto);
 
+    // Stub the course lookup used to set mcAttemptsMode on the DTO
+    Course course = new Course();
+    course.setId(courseId);
+    course.setMcAttemptsMode(McAttemptsMode.UNLIMITED);
+    when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
+
     ChallengeStudentDto result = challengeService.getChallengeForPlay(userId, courseId, challengeId);
 
     assertThat(result).isSameAs(dto);
+    assertThat(result.getMcAttemptsMode()).isEqualTo("UNLIMITED");
   }
 
   @Test

--- a/backend/src/test/java/com/pm4/istp/course/CourseControllerTest.java
+++ b/backend/src/test/java/com/pm4/istp/course/CourseControllerTest.java
@@ -169,7 +169,7 @@ class CourseControllerTest {
         when(courseMapper.toDto(course)).thenReturn(dto);
 
         CreateCourseRequestDto requestDto = new CreateCourseRequestDto(
-                "Secure Coding", "Desc", "Short desc.", false, false, null, null, List.of());
+                "Secure Coding", "Desc", "Short desc.", false, false, null, null, List.of(), "UNLIMITED");
 
         mockMvc
                 .perform(
@@ -184,7 +184,7 @@ class CourseControllerTest {
     @Test
     void createCourse_whenTitleBlank_returnsBadRequest() throws Exception {
         CreateCourseRequestDto requestDto = new CreateCourseRequestDto("", "Desc", "Short desc.", false, false, null,
-                null, List.of());
+                null, List.of(), "UNLIMITED");
 
         mockMvc
                 .perform(
@@ -320,7 +320,7 @@ class CourseControllerTest {
                 .thenReturn(List.of());
 
         UpdateCourseRequestDto requestDto = new UpdateCourseRequestDto(
-                "Updated Title", "Desc", "Short summary.", false, false, null, null, List.of());
+                "Updated Title", "Desc", "Short summary.", false, false, null, null, List.of(), "UNLIMITED");
 
         mockMvc
                 .perform(

--- a/backend/src/test/java/com/pm4/istp/course/CourseServiceImplTest.java
+++ b/backend/src/test/java/com/pm4/istp/course/CourseServiceImplTest.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.pm4.istp.course.db.CreateCourseInstructorRequest;
 import com.pm4.istp.course.db.CreateCourseRequest;
+import com.pm4.istp.course.db.entities.McAttemptsMode;
 import com.pm4.istp.course.db.InstructorRoleEnum;
 import com.pm4.istp.course.db.UpdateCourseInstructorRequest;
 import com.pm4.istp.course.db.UpdateCourseRequest;
@@ -117,7 +118,8 @@ class CourseServiceImplTest {
         false,
         null,
         null,
-        List.of(new CreateCourseInstructorRequest(collaboratorId, InstructorRoleEnum.COLLABORATOR)));
+        List.of(new CreateCourseInstructorRequest(collaboratorId, InstructorRoleEnum.COLLABORATOR)),
+        McAttemptsMode.UNLIMITED);
 
     Course result = courseService.createCourse(ownerId, request);
 
@@ -226,7 +228,8 @@ class CourseServiceImplTest {
         false,
         null,
         null,
-        List.of(new UpdateCourseInstructorRequest(newCollaboratorId, InstructorRoleEnum.COLLABORATOR)));
+        List.of(new UpdateCourseInstructorRequest(newCollaboratorId, InstructorRoleEnum.COLLABORATOR)),
+        McAttemptsMode.UNLIMITED);
 
     when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
     when(userRepository.findByIdAndDeletedAtIsNull(newCollaboratorId)).thenReturn(Optional.of(newCollaborator));
@@ -324,7 +327,8 @@ class CourseServiceImplTest {
         false,
         null,
         null,
-        List.of());
+        List.of(),
+        McAttemptsMode.UNLIMITED);
 
     assertThatThrownBy(() -> courseService.createCourse(ownerId, request))
         .isInstanceOf(InvalidCourseShortDescriptionException.class)
@@ -352,7 +356,8 @@ class CourseServiceImplTest {
         true,
         null,
         null,
-        List.of());
+        List.of(),
+        McAttemptsMode.UNLIMITED);
 
     assertThatThrownBy(() -> courseService.createCourse(ownerId, request))
         .isInstanceOf(IllegalArgumentException.class)
@@ -599,7 +604,7 @@ class CourseServiceImplTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
 
     CreateCourseRequest request = new CreateCourseRequest(
-        "Solo Course", "Desc", "Short solo summary.", false, false, null, null, List.of());
+        "Solo Course", "Desc", "Short solo summary.", false, false, null, null, List.of(), McAttemptsMode.UNLIMITED);
 
     Course result = courseService.createCourse(ownerId, request);
 
@@ -661,7 +666,7 @@ class CourseServiceImplTest {
     course.addCourseInstructor(ownerRelation);
 
     UpdateCourseRequest request = new UpdateCourseRequest(
-        "Title", "Desc", "Short summary.", false, false, null, null, List.of());
+        "Title", "Desc", "Short summary.", false, false, null, null, List.of(), McAttemptsMode.UNLIMITED);
 
     when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
 
@@ -679,7 +684,7 @@ class CourseServiceImplTest {
     when(courseRepository.findById(courseId)).thenReturn(Optional.empty());
 
     UpdateCourseRequest request = new UpdateCourseRequest(
-        "Title", "Desc", "Short summary.", false, false, null, null, List.of());
+        "Title", "Desc", "Short summary.", false, false, null, null, List.of(), McAttemptsMode.UNLIMITED);
 
     assertThatThrownBy(() -> courseService.updateCourse(userId, courseId, request))
         .isInstanceOf(CourseNotFoundException.class);
@@ -1251,7 +1256,8 @@ class CourseServiceImplTest {
         true,
         null,
         null,
-        List.of());
+        List.of(),
+        McAttemptsMode.UNLIMITED);
 
     when(courseRepository.findById(courseId)).thenReturn(Optional.of(course));
 
@@ -1310,7 +1316,8 @@ class CourseServiceImplTest {
         true,
         null,
         null,
-        List.of());
+        List.of(),
+        McAttemptsMode.UNLIMITED);
 
     assertThatThrownBy(() -> courseService.createCourse(ownerId, request))
         .isInstanceOf(InviteCodeGenerationException.class);
@@ -1349,7 +1356,8 @@ class CourseServiceImplTest {
         true,
         null,
         null,
-        List.of());
+        List.of(),
+        McAttemptsMode.UNLIMITED);
 
     assertThatThrownBy(() -> courseService.updateCourse(ownerId, courseId, updateRequest))
         .isInstanceOf(InviteCodeGenerationException.class);

--- a/frontend/src/app/dashboard/instructor/[id]/page.tsx
+++ b/frontend/src/app/dashboard/instructor/[id]/page.tsx
@@ -559,10 +559,19 @@ export default function EditCourse() {
                 <Select
                   label="Multiple-Choice Attempts"
                   value={mcAttemptsMode}
-                  onChange={(value) => { if (value) setMcAttemptsMode(value); }}
+                  onChange={(value) => {
+                    if (value) setMcAttemptsMode(value);
+                  }}
                   data={[
-                    { value: "UNLIMITED", label: "Unlimited — retry until correct (self-learning)" },
-                    { value: "ONCE", label: "Once — one attempt, graded regardless of correctness (Praktikum / exam)" },
+                    {
+                      value: "UNLIMITED",
+                      label: "Unlimited — retry until correct (self-learning)",
+                    },
+                    {
+                      value: "ONCE",
+                      label:
+                        "Once — one attempt, graded regardless of correctness (Praktikum / exam)",
+                    },
                   ]}
                   description="Controls how many times students can attempt MC questions in this course."
                   allowDeselect={false}

--- a/frontend/src/app/dashboard/instructor/[id]/page.tsx
+++ b/frontend/src/app/dashboard/instructor/[id]/page.tsx
@@ -106,6 +106,7 @@ export default function EditCourse() {
   const [deleteOpened, { open: openDelete, close: closeDelete }] = useDisclosure(false);
   const shortDescriptionCharCount = shortDescription.length;
 
+  const [mcAttemptsMode, setMcAttemptsMode] = useState<string>("UNLIMITED");
   const [inviteCode, setInviteCode] = useState<string | null>(null);
   const [isRegenerating, setIsRegenerating] = useState(false);
   const [regenerateError, setRegenerateError] = useState<string | null>(null);
@@ -143,6 +144,7 @@ export default function EditCourse() {
       setImageUrl(course.imageUrl ?? "");
       setTopic(course.topic ?? null);
       setInviteCode(course.inviteCode ?? null);
+      setMcAttemptsMode((course.mcAttemptsMode as string) ?? "UNLIMITED");
 
       // Extract collaborators (not OWNER) for the multi-select
       const collaborators = course.courseInstructors.filter(
@@ -213,6 +215,7 @@ export default function EditCourse() {
       imageUrl: imageUrl.trim() || null,
       topic: topic,
       collaboratorIds: selectedInstructors,
+      mcAttemptsMode,
     });
 
     if (!result.success) {
@@ -550,6 +553,18 @@ export default function EditCourse() {
                     { value: "PRIVATE", label: "Private (invite code only)" },
                   ]}
                   description="Choose exactly one state. Draft keeps it hidden, Public shows in catalog, Private is join-by-code only."
+                  allowDeselect={false}
+                />
+
+                <Select
+                  label="Multiple-Choice Attempts"
+                  value={mcAttemptsMode}
+                  onChange={(value) => { if (value) setMcAttemptsMode(value); }}
+                  data={[
+                    { value: "UNLIMITED", label: "Unlimited — retry until correct (self-learning)" },
+                    { value: "ONCE", label: "Once — one attempt, graded regardless of correctness (Praktikum / exam)" },
+                  ]}
+                  description="Controls how many times students can attempt MC questions in this course."
                   allowDeselect={false}
                 />
 

--- a/frontend/src/app/dashboard/instructor/create/page.tsx
+++ b/frontend/src/app/dashboard/instructor/create/page.tsx
@@ -42,6 +42,7 @@ export default function CreateCourse() {
   const [imageUrl, setImageUrl] = useState("");
   const [topic, setTopic] = useState<string | null>(null);
   const [selectedInstructors, setSelectedInstructors] = useState<string[]>([]);
+  const [mcAttemptsMode, setMcAttemptsMode] = useState<string>("UNLIMITED");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [titleError, setTitleError] = useState<string | null>(null);
   const [shortDescriptionError, setShortDescriptionError] = useState<string | null>(null);
@@ -80,6 +81,7 @@ export default function CreateCourse() {
       imageUrl: imageUrl.trim() || null,
       topic: topic,
       collaboratorIds: selectedInstructors,
+      mcAttemptsMode,
     });
 
     setIsSubmitting(false);
@@ -206,6 +208,18 @@ export default function CreateCourse() {
                 { value: "PRIVATE", label: "Private (invite code only)" },
               ]}
               description="Choose exactly one state. Draft keeps it hidden, Public shows in catalog, Private is join-by-code only."
+              allowDeselect={false}
+            />
+
+            <Select
+              label="Multiple-Choice Attempts"
+              value={mcAttemptsMode}
+              onChange={(value) => { if (value) setMcAttemptsMode(value); }}
+              data={[
+                { value: "UNLIMITED", label: "Unlimited — retry until correct (self-learning)" },
+                { value: "ONCE", label: "Once — one attempt, graded regardless of correctness (Praktikum / exam)" },
+              ]}
+              description="Controls how many times students can attempt MC questions in this course."
               allowDeselect={false}
             />
 

--- a/frontend/src/app/dashboard/instructor/create/page.tsx
+++ b/frontend/src/app/dashboard/instructor/create/page.tsx
@@ -214,10 +214,15 @@ export default function CreateCourse() {
             <Select
               label="Multiple-Choice Attempts"
               value={mcAttemptsMode}
-              onChange={(value) => { if (value) setMcAttemptsMode(value); }}
+              onChange={(value) => {
+                if (value) setMcAttemptsMode(value);
+              }}
               data={[
                 { value: "UNLIMITED", label: "Unlimited — retry until correct (self-learning)" },
-                { value: "ONCE", label: "Once — one attempt, graded regardless of correctness (Praktikum / exam)" },
+                {
+                  value: "ONCE",
+                  label: "Once — one attempt, graded regardless of correctness (Praktikum / exam)",
+                },
               ]}
               description="Controls how many times students can attempt MC questions in this course."
               allowDeselect={false}

--- a/frontend/src/features/course/actions/challenges.ts
+++ b/frontend/src/features/course/actions/challenges.ts
@@ -153,13 +153,14 @@ export async function submitSubTaskFlag(
 export async function submitSubTaskChoice(
   challengeId: string,
   subTaskId: string,
-  selectedOptionId: string
+  selectedOptionId: string,
+  courseId: string
 ): Promise<ActionResult<ChoiceSubmissionResponseDto>> {
   return await withActionResult(
     (client) =>
       client.POST("/api/v1/challenges/{challengeId}/subtasks/{subTaskId}/submit-choice", {
         params: { path: { challengeId, subTaskId } },
-        body: { selectedOptionId },
+        body: { selectedOptionId, courseId },
       }),
     "Failed to submit answer"
   );

--- a/frontend/src/features/course/components/play/ChallengePlayView.tsx
+++ b/frontend/src/features/course/components/play/ChallengePlayView.tsx
@@ -668,15 +668,15 @@ export function ChallengePlayView({
                             if (current.isSolved && isSelected && !isOnceModeWrongAnswer) {
                               bg = "rgba(20,184,166,0.12)";
                               border = "rgba(20,184,166,0.4)";
-                            // Correct option highlight (after wrong answer in any mode)
+                              // Correct option highlight (after wrong answer in any mode)
                             } else if (isCorrectOpt && hasWrongAnswer) {
                               bg = "rgba(20,184,166,0.10)";
                               border = "rgba(20,184,166,0.35)";
-                            // Wrong selected option: show red
+                              // Wrong selected option: show red
                             } else if (isWrongSelected) {
                               bg = "rgba(248,113,113,0.10)";
                               border = "rgba(248,113,113,0.35)";
-                            // Normal selection before submit
+                              // Normal selection before submit
                             } else if (!hasWrongAnswer && !current.isSolved && isSelected) {
                               bg = "rgba(59,130,246,0.10)";
                               border = "rgba(59,130,246,0.4)";
@@ -712,12 +712,14 @@ export function ChallengePlayView({
                                     style={{
                                       flex: 1,
                                       // Strikethrough on wrong selected option in ONCE mode
-                                      textDecoration: isOnceModeWrongAnswer && isWrongSelected
-                                        ? "line-through"
-                                        : undefined,
-                                      color: isOnceModeWrongAnswer && isWrongSelected
-                                        ? "var(--mantine-color-red-4)"
-                                        : undefined,
+                                      textDecoration:
+                                        isOnceModeWrongAnswer && isWrongSelected
+                                          ? "line-through"
+                                          : undefined,
+                                      color:
+                                        isOnceModeWrongAnswer && isWrongSelected
+                                          ? "var(--mantine-color-red-4)"
+                                          : undefined,
                                     }}
                                   >
                                     {opt.text}
@@ -753,13 +755,13 @@ export function ChallengePlayView({
                         onClick={() => void handleSubmitChoice()}
                         disabled={current.isSolved || hasWrongAnswer || !selectedOption}
                         loading={submitting}
-                        color={isOnceModeWrongAnswer ? "orange" : current.isSolved ? "teal" : "blue"}
+                        color={
+                          isOnceModeWrongAnswer ? "orange" : current.isSolved ? "teal" : "blue"
+                        }
                         leftSection={
-                          isOnceModeWrongAnswer
-                            ? undefined
-                            : current.isSolved
-                              ? <IconCheck size={16} />
-                              : undefined
+                          isOnceModeWrongAnswer ? undefined : current.isSolved ? (
+                            <IconCheck size={16} />
+                          ) : undefined
                         }
                       >
                         {isOnceModeWrongAnswer

--- a/frontend/src/features/course/components/play/ChallengePlayView.tsx
+++ b/frontend/src/features/course/components/play/ChallengePlayView.tsx
@@ -313,8 +313,10 @@ export function ChallengePlayView({
   async function handleSubmitChoice() {
     if (!current || !current.id || !challenge.id || !selectedOption) return;
 
+    const isOnceMode = (challenge.mcAttemptsMode ?? "UNLIMITED") === "ONCE";
+
     setSubmitting(true);
-    const result = await submitSubTaskChoice(challenge.id, current.id, selectedOption);
+    const result = await submitSubTaskChoice(challenge.id, current.id, selectedOption, courseId);
     setSubmitting(false);
 
     if (!result.success) {
@@ -323,30 +325,30 @@ export function ChallengePlayView({
     }
 
     if (result.data.isCorrect) {
+      // Correct in any mode → mark solved
       updateSubTaskSolved(current.id, { selectedOptionId: selectedOption });
       notifications.show({
         color: "teal",
         title: "Correct answer!",
         message: result.data.isChallengeSolved ? "Lab completed. Nice work!" : "Challenge solved.",
       });
+    } else if (isOnceMode) {
+      // ONCE mode + wrong: mark as done (progress counts), highlight correct option
+      updateSubTaskSolved(current.id, {
+        selectedOptionId: selectedOption,
+        correctOptionId: result.data.correctOptionId ?? undefined,
+      });
+      notifications.show({
+        color: "orange",
+        title: "Incorrect answer",
+        message: "That was your only attempt — the correct answer is highlighted.",
+      });
     } else {
-      // Record which option was picked and the correct option
-      setChallenge((prev) => ({
-        ...prev,
-        subTasks: (prev.subTasks ?? []).map((st) =>
-          st.id === current.id
-            ? {
-                ...st,
-                selectedOptionId: selectedOption,
-                correctOptionId: result.data.correctOptionId,
-              }
-            : st
-        ),
-      }));
+      // UNLIMITED mode + wrong: no state saved, allow retry
       notifications.show({
         color: "red",
         title: "Incorrect answer",
-        message: "That was wrong — the correct answer is highlighted below.",
+        message: "Not quite — try again!",
       });
     }
   }
@@ -381,7 +383,11 @@ export function ChallengePlayView({
     ? (current.selectedOptionId ?? selectedOption)
     : selectedOption;
   const correctOptionId = current?.correctOptionId ?? null;
-  const hasWrongAnswer = Boolean(!current?.isSolved && current?.selectedOptionId);
+  // ONCE mode: subtask is "solved" but the answer was wrong (correctOptionId is set on the subtask)
+  const isOnceModeWrongAnswer = Boolean(current?.isSolved && current?.correctOptionId);
+  // UNLIMITED mode: a wrong option was picked this session but not yet persisted → lock options temporarily
+  const hasWrongAnswer =
+    Boolean(!current?.isSolved && current?.selectedOptionId) || isOnceModeWrongAnswer;
 
   return (
     <Box
@@ -647,7 +653,7 @@ export function ChallengePlayView({
                       <Radio.Group
                         value={displaySelectedOption}
                         onChange={(val) => {
-                          if (!current.isSolved) setSelectedOption(val);
+                          if (!current.isSolved && !hasWrongAnswer) setSelectedOption(val);
                         }}
                       >
                         <Stack gap="xs">
@@ -658,16 +664,20 @@ export function ChallengePlayView({
 
                             let bg = "rgba(255,255,255,0.02)";
                             let border: string | undefined = undefined;
-                            if (current.isSolved && isSelected) {
+                            // Correct solved: selected option shown teal
+                            if (current.isSolved && isSelected && !isOnceModeWrongAnswer) {
                               bg = "rgba(20,184,166,0.12)";
                               border = "rgba(20,184,166,0.4)";
-                            } else if (isCorrectOpt) {
+                            // Correct option highlight (after wrong answer in any mode)
+                            } else if (isCorrectOpt && hasWrongAnswer) {
                               bg = "rgba(20,184,166,0.10)";
                               border = "rgba(20,184,166,0.35)";
+                            // Wrong selected option: show red
                             } else if (isWrongSelected) {
                               bg = "rgba(248,113,113,0.10)";
                               border = "rgba(248,113,113,0.35)";
-                            } else if (!hasWrongAnswer && isSelected) {
+                            // Normal selection before submit
+                            } else if (!hasWrongAnswer && !current.isSolved && isSelected) {
                               bg = "rgba(59,130,246,0.10)";
                               border = "rgba(59,130,246,0.4)";
                             }
@@ -697,17 +707,31 @@ export function ChallengePlayView({
                                     disabled={locked}
                                     style={{ flexShrink: 0 }}
                                   />
-                                  <Text size="sm" style={{ flex: 1 }}>
+                                  <Text
+                                    size="sm"
+                                    style={{
+                                      flex: 1,
+                                      // Strikethrough on wrong selected option in ONCE mode
+                                      textDecoration: isOnceModeWrongAnswer && isWrongSelected
+                                        ? "line-through"
+                                        : undefined,
+                                      color: isOnceModeWrongAnswer && isWrongSelected
+                                        ? "var(--mantine-color-red-4)"
+                                        : undefined,
+                                    }}
+                                  >
                                     {opt.text}
                                   </Text>
-                                  {current.isSolved && isSelected && (
+                                  {/* Correct answer checkmark (correct solved, not once-wrong) */}
+                                  {current.isSolved && isSelected && !isOnceModeWrongAnswer && (
                                     <IconCheck
                                       size={15}
                                       color="var(--mantine-color-teal-4)"
                                       style={{ flexShrink: 0 }}
                                     />
                                   )}
-                                  {isCorrectOpt && !current.isSolved && (
+                                  {/* Correct option highlight after any wrong answer */}
+                                  {isCorrectOpt && hasWrongAnswer && (
                                     <IconCheck
                                       size={15}
                                       color="var(--mantine-color-teal-4)"
@@ -729,10 +753,20 @@ export function ChallengePlayView({
                         onClick={() => void handleSubmitChoice()}
                         disabled={current.isSolved || hasWrongAnswer || !selectedOption}
                         loading={submitting}
-                        color={current.isSolved ? "teal" : "blue"}
-                        leftSection={current.isSolved ? <IconCheck size={16} /> : undefined}
+                        color={isOnceModeWrongAnswer ? "orange" : current.isSolved ? "teal" : "blue"}
+                        leftSection={
+                          isOnceModeWrongAnswer
+                            ? undefined
+                            : current.isSolved
+                              ? <IconCheck size={16} />
+                              : undefined
+                        }
                       >
-                        {current.isSolved ? "Answered" : "Submit answer"}
+                        {isOnceModeWrongAnswer
+                          ? "Attempted (wrong)"
+                          : current.isSolved
+                            ? "Answered"
+                            : "Submit answer"}
                       </Button>
                     </Stack>
                   )}


### PR DESCRIPTION
Add McAttemptsMode enum (ONCE/UNLIMITED) and mcAttemptsMode field to Course entity ONCE mode: submission always saved and sub-task marked complete even on wrong answer (graded/Praktikum); wrong option shown with red strikethrough, correct highlighted UNLIMITED mode: wrong answers not persisted, student can retry until correct (self-learning); progress only counts on correct answer Add courseId to ChoiceSubmissionRequestDto so MC mode can be resolved at submission time Expose mcAttemptsMode in ChallengeStudentDto for frontend rendering Add MC attempts Select to instructor course create/edit forms Update ChallengeServiceImplTest: add missing mocks, fix getChallengeForPlay stub