### PR TITLE
Rename variable to sanitizedLabDescription

### DIFF
--- a/frontend/src/features/course/components/play/LabPlayView.tsx
+++ b/frontend/src/features/course/components/play/LabPlayView.tsx
@@ -167,7 +167,7 @@ export function LabPlayView({
   const current = challenges[activeStep] ?? null;
   const allSolved = lab.isSolved ?? false;
 
-  const sanitizedChallengeDescription = useMemo(
+  const sanitizedLabDescription = useMemo(
     () => (lab.description ? getSanitizedHtml(lab.description) : ""),
     [lab.description]
   );
@@ -495,11 +495,11 @@ export function LabPlayView({
                 />
               </Stack>
 
-              {sanitizedChallengeDescription && (
+              {sanitizedLabDescription && (
                 <Box
                   className="course-description"
                   style={{ fontSize: "var(--mantine-font-size-sm)" }}
-                  dangerouslySetInnerHTML={{ __html: sanitizedChallengeDescription }}
+                  dangerouslySetInnerHTML={{ __html: sanitizedLabDescription }}
                 />
               )}
             </Stack>


### PR DESCRIPTION
Update LabPlayView.tsx to rename sanitizedChallengeDescription to sanitizedLabDescription and use it where the lab description HTML is rendered. The sanitized value is computed from lab.description via getSanitizedHtml and injected into the component's JSX (dangerouslySetInnerHTML). This clarifies the variable name and aligns it with the lab-level description (no runtime behavior changes).