### PR TITLE
fix: make dashboard and admin views responsive on small screens

### DIFF
--- a/frontend/src/app/dashboard/catalog/CatalogFilters.tsx
+++ b/frontend/src/app/dashboard/catalog/CatalogFilters.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Box, Group, Select, TextInput } from "@mantine/core";
-import JoinCourseButton from "@/src/features/course/components/enrollment/JoinCourseButton";
+import { Box, Flex, Group, Select, Stack, TextInput } from "@mantine/core";
 import AppButton from "@/src/shared/components/AppButton";
 
 type CatalogFiltersProps = {
@@ -27,33 +26,38 @@ export default function CatalogFilters({ query, topic, topics }: CatalogFiltersP
       }}
     >
       <form action="/dashboard/catalog" method="get">
-        <Group align="flex-end" wrap="wrap">
+        <Stack gap="md">
+          {/* Large search input on its own row */}
           <TextInput
             name="query"
             label="Search courses"
             placeholder="Search by title, short description, or description"
             defaultValue={query}
-            style={{ flex: 1 }}
           />
 
-          <Select
-            name="topic"
-            label="Topic"
-            data={topicData}
-            defaultValue={topic}
-            w={220}
-            searchable
-            comboboxProps={{ withinPortal: true, zIndex: 3000 }}
-          />
-
-          <Group gap="sm">
-            <JoinCourseButton size="sm" />
-            <AppButton type="submit">Search</AppButton>
-            <AppButton tone="ghost" component="a" href="/dashboard/catalog">
-              Reset
-            </AppButton>
-          </Group>
-        </Group>
+          {/* Topic filter grows to fill the space; actions sit beside it. */}
+          <Flex
+            direction={{ base: "column", sm: "row" }}
+            align={{ base: "stretch", sm: "flex-end" }}
+            gap="sm"
+          >
+            <Select
+              name="topic"
+              label="Topic"
+              data={topicData}
+              defaultValue={topic}
+              searchable
+              comboboxProps={{ withinPortal: true, zIndex: 3000 }}
+              style={{ flex: 1, minWidth: 180 }}
+            />
+            <Group gap="sm" grow>
+              <AppButton type="submit">Search</AppButton>
+              <AppButton tone="ghost" component="a" href="/dashboard/catalog">
+                Reset
+              </AppButton>
+            </Group>
+          </Flex>
+        </Stack>
       </form>
     </Box>
   );

--- a/frontend/src/app/dashboard/catalog/page.tsx
+++ b/frontend/src/app/dashboard/catalog/page.tsx
@@ -3,6 +3,7 @@ import { fetchCourseTopics, fetchPublishedCourses } from "@/src/features/course/
 import { CourseGrid } from "@/src/features/course/components/course/CourseGrid";
 import NotifyOnMount from "@/src/shared/components/NotifyOnMount";
 import PageHeader from "@/src/shared/components/PageHeader";
+import JoinCourseButton from "@/src/features/course/components/enrollment/JoinCourseButton";
 import { toUserFriendlyBackendError } from "@/src/shared/lib/userFriendlyBackendError";
 import CatalogFilters from "@/src/app/dashboard/catalog/CatalogFilters";
 
@@ -26,6 +27,7 @@ export default async function CatalogPage(props: {
       <PageHeader
         title="Browse Catalog"
         subtitle="Explore all published courses. Search by title or topic."
+        action={<JoinCourseButton size="sm" />}
       />
 
       <CatalogFilters query={query} topic={topic} topics={topics} />

--- a/frontend/src/app/dashboard/instructor/[id]/results/page.tsx
+++ b/frontend/src/app/dashboard/instructor/[id]/results/page.tsx
@@ -8,13 +8,16 @@ import {
   Avatar,
   Box,
   Container,
+  Flex,
   Group,
   Loader,
   Drawer,
   Modal,
+  ScrollArea,
   Select,
   SimpleGrid,
   Stack,
+  Table,
   Text,
   TextInput,
   Title,
@@ -477,14 +480,16 @@ export default function CourseResultsPage() {
         }}
       >
         {/* Toolbar */}
-        <Group
+        <Flex
+          direction={{ base: "column", sm: "row" }}
           justify="space-between"
-          align="center"
-          px="xl"
+          align={{ base: "stretch", sm: "center" }}
+          gap="sm"
+          px={{ base: "md", sm: "xl" }}
           py="md"
           style={{ borderBottom: "1px solid rgba(255,255,255,0.07)" }}
         >
-          <Group gap="sm" style={{ minWidth: 0 }}>
+          <Group gap="sm" wrap="wrap" style={{ minWidth: 0 }}>
             <Text fw={600} style={{ color: "#f1f5f9", fontSize: "1rem", whiteSpace: "nowrap" }}>
               Participants
             </Text>
@@ -495,7 +500,7 @@ export default function CourseResultsPage() {
               onChange={setLabFilter}
               clearable
               size="xs"
-              w={280}
+              w={{ base: "100%", sm: 260 }}
               styles={{
                 input: {
                   background: "rgba(255,255,255,0.05)",
@@ -514,7 +519,7 @@ export default function CourseResultsPage() {
               onChange={(v) => setStatusFilter((v as SubmissionStatus) ?? null)}
               clearable
               size="xs"
-              w={170}
+              w={{ base: "100%", sm: 170 }}
               styles={{
                 input: {
                   background: "rgba(255,255,255,0.05)",
@@ -533,7 +538,7 @@ export default function CourseResultsPage() {
             value={search}
             onChange={(e) => setSearch(e.currentTarget.value)}
             size="xs"
-            w={230}
+            w={{ base: "100%", sm: 230 }}
             styles={{
               input: {
                 background: "rgba(255,255,255,0.05)",
@@ -543,141 +548,140 @@ export default function CourseResultsPage() {
               },
             }}
           />
-        </Group>
+        </Flex>
 
-        {/* Column headers */}
-        <Box
-          style={{
-            display: "grid",
-            gridTemplateColumns: "2.5fr 1.2fr 1.8fr 1.8fr",
-            padding: "0.6rem 1.5rem",
-            background: "rgba(255,255,255,0.02)",
-            borderBottom: "1px solid rgba(255,255,255,0.06)",
-          }}
-        >
-          {["Participant", "Status", "Points / Challenges", "Completion"].map((h) => (
-            <Text
-              key={h}
-              size="xs"
-              fw={700}
-              style={{ color: "#475569", letterSpacing: "0.1em", textTransform: "uppercase" }}
-            >
-              {h}
-            </Text>
-          ))}
-        </Box>
-
-        {loading ? (
-          <Group justify="center" py="xl">
-            <Loader size="sm" />
-          </Group>
-        ) : filteredRows.length === 0 ? (
-          <Text size="sm" c="dimmed" p="xl" ta="center">
-            No participants found.
-          </Text>
-        ) : (
-          filteredRows.map((r) => {
-            const status = r.currentLabStatus;
-            const currentIndex =
-              r.currentLabId != null ? labs.findIndex((l) => l.labId === r.currentLabId) : -1;
-            const labMeta =
-              r.currentLabId && currentIndex >= 0
-                ? `Lab ${String(currentIndex + 1).padStart(2, "0")}`
-                : null;
-            const currentMeta = labMeta
-              ? `${labMeta}${r.currentLabTitle ? `: ${r.currentLabTitle}` : ""}`
-              : null;
-            return (
-              <Box
-                key={r.participant.id}
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "2.5fr 1.2fr 1.8fr 1.8fr",
-                  padding: "0.85rem 1.5rem",
-                  borderBottom: "1px solid rgba(255,255,255,0.04)",
-                  alignItems: "center",
-                  cursor: "pointer",
-                }}
-                onClick={() => {
-                  openDrawer(r);
-                }}
-              >
-                <Group gap="sm">
-                  <Avatar
-                    color={avatarColor(r.participant.name)}
-                    radius="md"
-                    size={36}
-                    style={{ fontWeight: 700, fontSize: "0.8rem" }}
-                  >
-                    {initials(r.participant.name)}
-                  </Avatar>
-                  <Stack gap={1}>
-                    <Text size="sm" fw={600} style={{ color: "#f1f5f9", lineHeight: 1.2 }}>
-                      {r.participant.name}
+        <ScrollArea>
+          <Table miw={760} highlightOnHover verticalSpacing="sm" horizontalSpacing="xl">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Participant</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th>Points / Challenges</Table.Th>
+                <Table.Th>Completion</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {loading ? (
+                <Table.Tr>
+                  <Table.Td colSpan={4}>
+                    <Group justify="center" py="xl">
+                      <Loader size="sm" />
+                    </Group>
+                  </Table.Td>
+                </Table.Tr>
+              ) : filteredRows.length === 0 ? (
+                <Table.Tr>
+                  <Table.Td colSpan={4}>
+                    <Text size="sm" c="dimmed" py="xl" ta="center">
+                      No participants found.
                     </Text>
-                    <Text size="xs" style={{ color: "#475569" }}>
-                      {r.participant.email ?? "-"}
-                    </Text>
-                  </Stack>
-                </Group>
+                  </Table.Td>
+                </Table.Tr>
+              ) : (
+                filteredRows.map((r) => {
+                  const status = r.currentLabStatus;
+                  const currentIndex =
+                    r.currentLabId != null ? labs.findIndex((l) => l.labId === r.currentLabId) : -1;
+                  const labMeta =
+                    r.currentLabId && currentIndex >= 0
+                      ? `Lab ${String(currentIndex + 1).padStart(2, "0")}`
+                      : null;
+                  const currentMeta = labMeta
+                    ? `${labMeta}${r.currentLabTitle ? `: ${r.currentLabTitle}` : ""}`
+                    : null;
+                  return (
+                    <Table.Tr
+                      key={r.participant.id}
+                      style={{ cursor: "pointer" }}
+                      onClick={() => openDrawer(r)}
+                    >
+                      <Table.Td>
+                        <Group gap="sm" wrap="nowrap">
+                          <Avatar
+                            color={avatarColor(r.participant.name)}
+                            radius="md"
+                            size={36}
+                            style={{ fontWeight: 700, fontSize: "0.8rem" }}
+                          >
+                            {initials(r.participant.name)}
+                          </Avatar>
+                          <Stack gap={1}>
+                            <Text size="sm" fw={600} style={{ color: "#f1f5f9", lineHeight: 1.2 }}>
+                              {r.participant.name}
+                            </Text>
+                            <Text size="xs" style={{ color: "#475569" }}>
+                              {r.participant.email ?? "-"}
+                            </Text>
+                          </Stack>
+                        </Group>
+                      </Table.Td>
 
-                <Tooltip
-                  withArrow
-                  position="top"
-                  label={
-                    currentMeta
-                      ? `Current: ${statusLabel(status)} · ${currentMeta}`
-                      : statusLabel(status)
-                  }
-                >
-                  <Group gap={10} wrap="nowrap">
-                    <span style={{ ...statusBadgeStyle(status), cursor: "help" }}>
-                      {statusLabel(status)}
-                    </span>
-                    {labMeta ? (
-                      <Text size="xs" style={{ color: "#475569" }}>
-                        {labMeta}
-                      </Text>
-                    ) : null}
-                  </Group>
-                </Tooltip>
+                      <Table.Td>
+                        <Tooltip
+                          withArrow
+                          position="top"
+                          label={
+                            currentMeta
+                              ? `Current: ${statusLabel(status)} · ${currentMeta}`
+                              : statusLabel(status)
+                          }
+                        >
+                          <Group gap={10} wrap="nowrap">
+                            <span style={{ ...statusBadgeStyle(status), cursor: "help" }}>
+                              {statusLabel(status)}
+                            </span>
+                            {labMeta ? (
+                              <Text size="xs" style={{ color: "#475569" }}>
+                                {labMeta}
+                              </Text>
+                            ) : null}
+                          </Group>
+                        </Tooltip>
+                      </Table.Td>
 
-                <Stack gap={2}>
-                  <Text size="sm" fw={700} style={{ color: "#f1f5f9" }}>
-                    {r.awardedPoints}/{r.maxPoints} pts
-                  </Text>
-                  <Text size="xs" style={{ color: "#475569" }}>
-                    {r.solvedChallenges}/{r.totalChallenges} challenges
-                  </Text>
-                </Stack>
+                      <Table.Td>
+                        <Stack gap={2}>
+                          <Text size="sm" fw={700} style={{ color: "#f1f5f9" }}>
+                            {r.awardedPoints}/{r.maxPoints} pts
+                          </Text>
+                          <Text size="xs" style={{ color: "#475569" }}>
+                            {r.solvedChallenges}/{r.totalChallenges} challenges
+                          </Text>
+                        </Stack>
+                      </Table.Td>
 
-                <Stack gap={4}>
-                  <Text size="xs" style={{ color: "#94a3b8" }}>
-                    {r.completionPct}%
-                  </Text>
-                  <Box
-                    style={{
-                      height: 5,
-                      borderRadius: 4,
-                      background: "rgba(255,255,255,0.07)",
-                      overflow: "hidden",
-                    }}
-                  >
-                    <Box
-                      style={{
-                        height: "100%",
-                        width: `${r.completionPct}%`,
-                        background: progressColor(status),
-                        borderRadius: 4,
-                        transition: "width 0.3s",
-                      }}
-                    />
-                  </Box>
-                </Stack>
-              </Box>
-            );
-          })
-        )}
+                      <Table.Td>
+                        <Stack gap={4} miw={140}>
+                          <Text size="xs" style={{ color: "#94a3b8" }}>
+                            {r.completionPct}%
+                          </Text>
+                          <Box
+                            style={{
+                              height: 5,
+                              borderRadius: 4,
+                              background: "rgba(255,255,255,0.07)",
+                              overflow: "hidden",
+                            }}
+                          >
+                            <Box
+                              style={{
+                                height: "100%",
+                                width: `${r.completionPct}%`,
+                                background: progressColor(status),
+                                borderRadius: 4,
+                                transition: "width 0.3s",
+                              }}
+                            />
+                          </Box>
+                        </Stack>
+                      </Table.Td>
+                    </Table.Tr>
+                  );
+                })
+              )}
+            </Table.Tbody>
+          </Table>
+        </ScrollArea>
       </Box>
 
       <Drawer

--- a/frontend/src/features/admin/components/AdminChallengeManagement.tsx
+++ b/frontend/src/features/admin/components/AdminChallengeManagement.tsx
@@ -5,11 +5,10 @@ import {
   ActionIcon,
   Alert,
   Badge,
-  Button,
   Group,
-  Loader,
   Modal,
   Pagination,
+  ScrollArea,
   Select,
   Stack,
   Table,
@@ -18,9 +17,10 @@ import {
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { notifications } from "@mantine/notifications";
-import { IconPencil, IconSearch, IconTrash } from "@tabler/icons-react";
+import { IconPencil, IconTrash } from "@tabler/icons-react";
 import { useAdminPagedList } from "@/src/features/admin/hooks/useAdminPagedList";
 import { cleanText, formatDate, wrapTextStyle } from "@/src/features/admin/lib/adminUi";
+import AdminListSearch from "@/src/features/admin/components/AdminListSearch";
 import AppButton from "@/src/shared/components/AppButton";
 import MyEditor from "@/src/shared/components/MyEditor";
 import { readBackendError } from "@/src/shared/lib/readBackendError";
@@ -182,32 +182,12 @@ export default function AdminChallengeManagement() {
 
   return (
     <Stack gap="md">
-      <Group justify="space-between" align="flex-end" wrap="wrap">
-        <Group gap="sm" wrap="wrap">
-          <TextInput
-            label="Search"
-            placeholder="Title / description..."
-            leftSection={<IconSearch size={16} />}
-            value={query}
-            onChange={(e) => onQueryChange(e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                applyQueryNow();
-              }
-            }}
-            w={420}
-          />
-        </Group>
-        {loading && (
-          <Group gap="xs">
-            <Loader size="sm" />
-            <Text size="sm" c="dimmed">
-              Loading
-            </Text>
-          </Group>
-        )}
-      </Group>
+      <AdminListSearch
+        query={query}
+        onQueryChange={onQueryChange}
+        applyQueryNow={applyQueryNow}
+        loading={loading}
+      />
       <Alert color="orange" title="Delete" variant="light">
         <Text size="sm">
           Deleting a lab removes it from active lists so students and instructors can no longer
@@ -215,107 +195,119 @@ export default function AdminChallengeManagement() {
         </Text>
       </Alert>
 
-      <Table highlightOnHover withTableBorder striped={false} style={{ tableLayout: "fixed" }}>
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>Title</Table.Th>
-            <Table.Th style={{ width: 240 }}>Creator</Table.Th>
-            <Table.Th>Status</Table.Th>
-            <Table.Th style={{ width: 150 }}>State</Table.Th>
-            <Table.Th style={{ width: 190 }}>Updated</Table.Th>
-            <Table.Th style={{ width: 130 }} />
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {labs.length === 0 ? (
+      <ScrollArea>
+        <Table
+          highlightOnHover
+          withTableBorder
+          striped={false}
+          miw={950}
+          style={{ tableLayout: "fixed" }}
+        >
+          <Table.Thead>
             <Table.Tr>
-              <Table.Td colSpan={6}>
-                <Text size="sm" c="dimmed" ta="center" py="md">
-                  No labs found.
-                </Text>
-              </Table.Td>
+              <Table.Th>Title</Table.Th>
+              <Table.Th style={{ width: 240 }}>Creator</Table.Th>
+              <Table.Th>Status</Table.Th>
+              <Table.Th style={{ width: 150 }}>State</Table.Th>
+              <Table.Th style={{ width: 190 }}>Updated</Table.Th>
+              <Table.Th style={{ width: 130 }} />
             </Table.Tr>
-          ) : (
-            labs.map((c) => (
-              <Table.Tr key={c.id}>
-                <Table.Td>
-                  <Text fw={600} size="sm" lineClamp={2} style={wrapTextStyle} title={c.title}>
-                    {c.title}
+          </Table.Thead>
+          <Table.Tbody>
+            {labs.length === 0 ? (
+              <Table.Tr>
+                <Table.Td colSpan={6}>
+                  <Text size="sm" c="dimmed" ta="center" py="md">
+                    No labs found.
                   </Text>
                 </Table.Td>
-                <Table.Td>
-                  <Stack gap={2}>
-                    <Text
-                      size="sm"
-                      lineClamp={1}
-                      style={wrapTextStyle}
-                      title={c.creatorName ?? "-"}
-                    >
-                      {c.creatorName ?? "-"}
-                    </Text>
-                    <Text
-                      size="xs"
-                      c="dimmed"
-                      lineClamp={1}
-                      style={wrapTextStyle}
-                      title={c.creatorUsername ? `@${c.creatorUsername}` : ""}
-                    >
-                      {c.creatorUsername ? `@${c.creatorUsername}` : ""}
-                    </Text>
-                  </Stack>
-                </Table.Td>
-                <Table.Td>
-                  <Group gap="xs">
-                    <Badge
-                      variant="light"
-                      color={
-                        c.status === "PUBLIC" ? "green" : c.status === "PRIVATE" ? "yellow" : "gray"
-                      }
-                    >
-                      {c.status}
-                    </Badge>
-                    <Badge variant="light" color="blue">
-                      {c.difficulty}
-                    </Badge>
-                    <Badge variant="light" color="grape">
-                      Courses: {c.courseCount}
-                    </Badge>
-                  </Group>
-                </Table.Td>
-                <Table.Td>
-                  <Badge variant="light" color={c.isSoftDeleted ? "orange" : "teal"}>
-                    {c.isSoftDeleted ? "Deleted" : "Active"}
-                  </Badge>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm">{formatDate(c.updatedAt)}</Text>
-                </Table.Td>
-                <Table.Td>
-                  <Group justify="flex-end" gap="xs" wrap="nowrap">
-                    <ActionIcon
-                      variant="subtle"
-                      color="gray"
-                      aria-label="Edit lab"
-                      onClick={() => openEdit(c)}
-                    >
-                      <IconPencil size={16} />
-                    </ActionIcon>
-                    <ActionIcon
-                      variant="subtle"
-                      color="red"
-                      aria-label="Delete lab"
-                      onClick={() => openDelete(c)}
-                      disabled={c.isSoftDeleted}
-                    >
-                      <IconTrash size={16} />
-                    </ActionIcon>
-                  </Group>
-                </Table.Td>
               </Table.Tr>
-            ))
-          )}
-        </Table.Tbody>
-      </Table>
+            ) : (
+              labs.map((c) => (
+                <Table.Tr key={c.id}>
+                  <Table.Td>
+                    <Text fw={600} size="sm" lineClamp={2} style={wrapTextStyle} title={c.title}>
+                      {c.title}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Stack gap={2}>
+                      <Text
+                        size="sm"
+                        lineClamp={1}
+                        style={wrapTextStyle}
+                        title={c.creatorName ?? "-"}
+                      >
+                        {c.creatorName ?? "-"}
+                      </Text>
+                      <Text
+                        size="xs"
+                        c="dimmed"
+                        lineClamp={1}
+                        style={wrapTextStyle}
+                        title={c.creatorUsername ? `@${c.creatorUsername}` : ""}
+                      >
+                        {c.creatorUsername ? `@${c.creatorUsername}` : ""}
+                      </Text>
+                    </Stack>
+                  </Table.Td>
+                  <Table.Td>
+                    <Group gap="xs">
+                      <Badge
+                        variant="light"
+                        color={
+                          c.status === "PUBLIC"
+                            ? "green"
+                            : c.status === "PRIVATE"
+                              ? "yellow"
+                              : "gray"
+                        }
+                      >
+                        {c.status}
+                      </Badge>
+                      <Badge variant="light" color="blue">
+                        {c.difficulty}
+                      </Badge>
+                      <Badge variant="light" color="grape">
+                        Courses: {c.courseCount}
+                      </Badge>
+                    </Group>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge variant="light" color={c.isSoftDeleted ? "orange" : "teal"}>
+                      {c.isSoftDeleted ? "Deleted" : "Active"}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="sm">{formatDate(c.updatedAt)}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Group justify="flex-end" gap="xs" wrap="nowrap">
+                      <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        aria-label="Edit lab"
+                        onClick={() => openEdit(c)}
+                      >
+                        <IconPencil size={16} />
+                      </ActionIcon>
+                      <ActionIcon
+                        variant="subtle"
+                        color="red"
+                        aria-label="Delete lab"
+                        onClick={() => openDelete(c)}
+                        disabled={c.isSoftDeleted}
+                      >
+                        <IconTrash size={16} />
+                      </ActionIcon>
+                    </Group>
+                  </Table.Td>
+                </Table.Tr>
+              ))
+            )}
+          </Table.Tbody>
+        </Table>
+      </ScrollArea>
 
       {totalPages > 1 && (
         <Group justify="center">
@@ -404,17 +396,12 @@ export default function AdminChallengeManagement() {
             This action cannot be undone.
           </Text>
           <Group justify="flex-end">
-            <Button
-              variant="default"
-              radius="md"
-              onClick={() => setDeleteOpened(false)}
-              disabled={saving}
-            >
+            <AppButton tone="ghost" onClick={() => setDeleteOpened(false)} disabled={saving}>
               Cancel
-            </Button>
-            <Button color="red" radius="md" onClick={() => void confirmDelete()} loading={saving}>
+            </AppButton>
+            <AppButton tone="danger" onClick={() => void confirmDelete()} loading={saving}>
               Delete
-            </Button>
+            </AppButton>
           </Group>
         </Stack>
       </Modal>

--- a/frontend/src/features/admin/components/AdminConfigForm.tsx
+++ b/frontend/src/features/admin/components/AdminConfigForm.tsx
@@ -5,8 +5,8 @@ import { useRouter } from "next/navigation";
 import {
   Center,
   Fieldset,
+  Flex,
   Grid,
-  Group,
   NumberInput,
   Select,
   Stack,
@@ -191,7 +191,7 @@ export default function AdminConfigForm({ initialConfig }: Props) {
           </Grid.Col>
           <Grid.Col span={12}>
             <Grid align="flex-end">
-              <Grid.Col span={8}>
+              <Grid.Col span={{ base: 12, xs: 8 }}>
                 <NumberInput
                   id="memory-limit-input"
                   label="Memory limit"
@@ -206,7 +206,7 @@ export default function AdminConfigForm({ initialConfig }: Props) {
                   withAsterisk={config.memoryLimit != null}
                 />
               </Grid.Col>
-              <Grid.Col span={4}>
+              <Grid.Col span={{ base: 12, xs: 4 }}>
                 <Select
                   id="memory-unit-input"
                   label="Memory unit"
@@ -282,7 +282,7 @@ export default function AdminConfigForm({ initialConfig }: Props) {
                   transition: "border-color 150ms ease, background 150ms ease",
                 }}
               >
-                <Center py="md">
+                <Center py="md" px="md">
                   <Dropzone.Accept>
                     <IconCloudUpload size={40} color="#2563eb" />
                   </Dropzone.Accept>
@@ -291,22 +291,22 @@ export default function AdminConfigForm({ initialConfig }: Props) {
                   </Dropzone.Reject>
                   <Dropzone.Idle>
                     {selectedFile ? (
-                      <Stack align="center" gap={6}>
+                      <Stack align="center" gap={6} style={{ maxWidth: "100%" }}>
                         <IconFile size={40} color="#94a3b8" />
-                        <Text size="sm" c="dimmed">
+                        <Text size="sm" c="dimmed" ta="center" style={{ wordBreak: "break-all" }}>
                           {selectedFile.name}
                         </Text>
-                        <Text size="xs" c="dimmed">
+                        <Text size="xs" c="dimmed" ta="center">
                           Click to replace
                         </Text>
                       </Stack>
                     ) : (
-                      <Stack align="center" gap={6}>
+                      <Stack align="center" gap={6} style={{ maxWidth: "100%" }}>
                         <IconCloudUpload size={40} color="#94a3b8" />
-                        <Text size="sm" fw={500}>
+                        <Text size="sm" fw={500} ta="center">
                           Drag &amp; drop your kubeconfig here
                         </Text>
-                        <Text size="xs" c="dimmed">
+                        <Text size="xs" c="dimmed" ta="center">
                           or
                         </Text>
                         <AppButton
@@ -339,7 +339,13 @@ export default function AdminConfigForm({ initialConfig }: Props) {
           </Grid.Col>
         </Grid>
 
-        <Group justify="space-between" mt="md">
+        <Flex
+          direction={{ base: "column", sm: "row" }}
+          align={{ base: "stretch", sm: "center" }}
+          justify="space-between"
+          gap="sm"
+          mt="md"
+        >
           <AppButton id="admin-config-form-submit-button" type="submit" loading={form.submitting}>
             {!config.kubeconfigUploaded
               ? "Create Kubernetes configuration"
@@ -354,7 +360,7 @@ export default function AdminConfigForm({ initialConfig }: Props) {
           >
             Delete Kubernetes configuration
           </AppButton>
-        </Group>
+        </Flex>
       </Fieldset>
     </form>
   );

--- a/frontend/src/features/admin/components/AdminCourseManagement.tsx
+++ b/frontend/src/features/admin/components/AdminCourseManagement.tsx
@@ -5,11 +5,10 @@ import {
   ActionIcon,
   Alert,
   Badge,
-  Button,
   Group,
-  Loader,
   Modal,
   Pagination,
+  ScrollArea,
   Select,
   Stack,
   Table,
@@ -19,9 +18,10 @@ import {
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { notifications } from "@mantine/notifications";
-import { IconPencil, IconSearch, IconTrash } from "@tabler/icons-react";
+import { IconPencil, IconTrash } from "@tabler/icons-react";
 import { useAdminPagedList } from "@/src/features/admin/hooks/useAdminPagedList";
 import { cleanText, formatDate, wrapTextStyle } from "@/src/features/admin/lib/adminUi";
+import AdminListSearch from "@/src/features/admin/components/AdminListSearch";
 import AppButton from "@/src/shared/components/AppButton";
 import { useCourseTopicOptions } from "@/src/features/course/hooks/useCourseTopicOptions";
 import MyEditor from "@/src/shared/components/MyEditor";
@@ -197,32 +197,12 @@ export default function AdminCourseManagement() {
 
   return (
     <Stack gap="md">
-      <Group justify="space-between" align="flex-end" wrap="wrap">
-        <Group gap="sm" wrap="wrap">
-          <TextInput
-            label="Search"
-            placeholder="Title / description..."
-            leftSection={<IconSearch size={16} />}
-            value={query}
-            onChange={(e) => onQueryChange(e.currentTarget.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                applyQueryNow();
-              }
-            }}
-            w={420}
-          />
-        </Group>
-        {loading && (
-          <Group gap="xs">
-            <Loader size="sm" />
-            <Text size="sm" c="dimmed">
-              Loading
-            </Text>
-          </Group>
-        )}
-      </Group>
+      <AdminListSearch
+        query={query}
+        onQueryChange={onQueryChange}
+        applyQueryNow={applyQueryNow}
+        loading={loading}
+      />
       <Alert color="orange" title="Delete" variant="light">
         <Text size="sm">
           Deleting a course removes it from active lists so students and instructors can no longer
@@ -230,112 +210,124 @@ export default function AdminCourseManagement() {
         </Text>
       </Alert>
 
-      <Table
-        highlightOnHover
-        withTableBorder
-        withColumnBorders={false}
-        striped={false}
-        style={{ tableLayout: "fixed" }}
-      >
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>Title</Table.Th>
-            <Table.Th style={{ width: 240 }}>Owner</Table.Th>
-            <Table.Th style={{ width: 190 }}>Visibility</Table.Th>
-            <Table.Th style={{ width: 190 }}>Updated</Table.Th>
-            <Table.Th style={{ width: 130 }} />
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {courses.length === 0 ? (
+      <ScrollArea>
+        <Table
+          highlightOnHover
+          withTableBorder
+          withColumnBorders={false}
+          striped={false}
+          miw={820}
+          style={{ tableLayout: "fixed" }}
+        >
+          <Table.Thead>
             <Table.Tr>
-              <Table.Td colSpan={5}>
-                <Text size="sm" c="dimmed" ta="center" py="md">
-                  No courses found.
-                </Text>
-              </Table.Td>
+              <Table.Th>Title</Table.Th>
+              <Table.Th style={{ width: 240 }}>Owner</Table.Th>
+              <Table.Th style={{ width: 190 }}>Visibility</Table.Th>
+              <Table.Th style={{ width: 190 }}>Updated</Table.Th>
+              <Table.Th style={{ width: 130 }} />
             </Table.Tr>
-          ) : (
-            courses.map((c) => (
-              <Table.Tr key={c.id}>
-                <Table.Td>
-                  <Stack gap={2}>
-                    <Text fw={600} size="sm" lineClamp={1} style={wrapTextStyle} title={c.title}>
-                      {c.title}
-                    </Text>
-                    {c.shortDescription ? (
+          </Table.Thead>
+          <Table.Tbody>
+            {courses.length === 0 ? (
+              <Table.Tr>
+                <Table.Td colSpan={5}>
+                  <Text size="sm" c="dimmed" ta="center" py="md">
+                    No courses found.
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            ) : (
+              courses.map((c) => (
+                <Table.Tr key={c.id}>
+                  <Table.Td>
+                    <Stack gap={2}>
+                      <Text fw={600} size="sm" lineClamp={1} style={wrapTextStyle} title={c.title}>
+                        {c.title}
+                      </Text>
+                      {c.shortDescription ? (
+                        <Text
+                          size="xs"
+                          c="dimmed"
+                          lineClamp={2}
+                          style={wrapTextStyle}
+                          title={c.shortDescription}
+                        >
+                          {c.shortDescription}
+                        </Text>
+                      ) : null}
+                    </Stack>
+                  </Table.Td>
+                  <Table.Td>
+                    <Stack gap={2}>
+                      <Text
+                        size="sm"
+                        lineClamp={1}
+                        style={wrapTextStyle}
+                        title={c.ownerName ?? "-"}
+                      >
+                        {c.ownerName ?? "-"}
+                      </Text>
                       <Text
                         size="xs"
                         c="dimmed"
-                        lineClamp={2}
+                        lineClamp={1}
                         style={wrapTextStyle}
-                        title={c.shortDescription}
+                        title={c.ownerUsername ? `@${c.ownerUsername}` : ""}
                       >
-                        {c.shortDescription}
+                        {c.ownerUsername ? `@${c.ownerUsername}` : ""}
                       </Text>
-                    ) : null}
-                  </Stack>
-                </Table.Td>
-                <Table.Td>
-                  <Stack gap={2}>
-                    <Text size="sm" lineClamp={1} style={wrapTextStyle} title={c.ownerName ?? "-"}>
-                      {c.ownerName ?? "-"}
-                    </Text>
-                    <Text
-                      size="xs"
-                      c="dimmed"
-                      lineClamp={1}
-                      style={wrapTextStyle}
-                      title={c.ownerUsername ? `@${c.ownerUsername}` : ""}
-                    >
-                      {c.ownerUsername ? `@${c.ownerUsername}` : ""}
-                    </Text>
-                  </Stack>
-                </Table.Td>
-                <Table.Td>
-                  <Group gap="xs">
-                    <Badge
-                      variant="light"
-                      color={
-                        c.status === "PRIVATE" ? "yellow" : c.status === "PUBLIC" ? "green" : "gray"
-                      }
-                    >
-                      {c.status === "PRIVATE"
-                        ? "Private"
-                        : c.status === "PUBLIC"
-                          ? "Public"
-                          : "Draft"}
-                    </Badge>
-                  </Group>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm">{formatDate(c.updatedAt)}</Text>
-                </Table.Td>
-                <Table.Td>
-                  <Group justify="flex-end" gap="xs" wrap="nowrap">
-                    <ActionIcon
-                      variant="subtle"
-                      color="gray"
-                      aria-label="Edit course"
-                      onClick={() => openEdit(c)}
-                    >
-                      <IconPencil size={16} />
-                    </ActionIcon>
-                    <ActionIcon
-                      variant="subtle"
-                      color="red"
-                      aria-label="Delete course"
-                      onClick={() => openDelete(c)}
-                    >
-                      <IconTrash size={16} />
-                    </ActionIcon>
-                  </Group>
-                </Table.Td>
-              </Table.Tr>
-            ))
-          )}
-        </Table.Tbody>
-      </Table>
+                    </Stack>
+                  </Table.Td>
+                  <Table.Td>
+                    <Group gap="xs">
+                      <Badge
+                        variant="light"
+                        color={
+                          c.status === "PRIVATE"
+                            ? "yellow"
+                            : c.status === "PUBLIC"
+                              ? "green"
+                              : "gray"
+                        }
+                      >
+                        {c.status === "PRIVATE"
+                          ? "Private"
+                          : c.status === "PUBLIC"
+                            ? "Public"
+                            : "Draft"}
+                      </Badge>
+                    </Group>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="sm">{formatDate(c.updatedAt)}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Group justify="flex-end" gap="xs" wrap="nowrap">
+                      <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        aria-label="Edit course"
+                        onClick={() => openEdit(c)}
+                      >
+                        <IconPencil size={16} />
+                      </ActionIcon>
+                      <ActionIcon
+                        variant="subtle"
+                        color="red"
+                        aria-label="Delete course"
+                        onClick={() => openDelete(c)}
+                      >
+                        <IconTrash size={16} />
+                      </ActionIcon>
+                    </Group>
+                  </Table.Td>
+                </Table.Tr>
+              ))
+            )}
+          </Table.Tbody>
+        </Table>
+      </ScrollArea>
 
       {totalPages > 1 && (
         <Group justify="center">
@@ -440,17 +432,12 @@ export default function AdminCourseManagement() {
             ? Students and instructors will no longer see it in active lists.
           </Text>
           <Group justify="flex-end">
-            <Button
-              variant="default"
-              radius="md"
-              onClick={() => setDeleteOpened(false)}
-              disabled={saving}
-            >
+            <AppButton tone="ghost" onClick={() => setDeleteOpened(false)} disabled={saving}>
               Cancel
-            </Button>
-            <Button color="red" radius="md" onClick={() => void confirmDelete()} loading={saving}>
+            </AppButton>
+            <AppButton tone="danger" onClick={() => void confirmDelete()} loading={saving}>
               Delete
-            </Button>
+            </AppButton>
           </Group>
         </Stack>
       </Modal>

--- a/frontend/src/features/admin/components/AdminListSearch.tsx
+++ b/frontend/src/features/admin/components/AdminListSearch.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Group, Loader, Text, TextInput } from "@mantine/core";
+import { IconSearch } from "@tabler/icons-react";
+
+interface AdminListSearchProps {
+  query: string;
+  onQueryChange: (value: string) => void;
+  applyQueryNow: () => void;
+  loading: boolean;
+}
+
+/**
+ * Shared search bar for the admin list views (courses, labs). Pairs with
+ * `useAdminPagedList`, which exposes exactly these handlers.
+ */
+export default function AdminListSearch({
+  query,
+  onQueryChange,
+  applyQueryNow,
+  loading,
+}: AdminListSearchProps) {
+  return (
+    <Group justify="space-between" align="flex-end" wrap="wrap">
+      <Group gap="sm" wrap="wrap" style={{ flex: 1 }}>
+        <TextInput
+          label="Search"
+          placeholder="Title / description..."
+          leftSection={<IconSearch size={16} />}
+          value={query}
+          onChange={(e) => onQueryChange(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              applyQueryNow();
+            }
+          }}
+          w={{ base: "100%", sm: 420 }}
+        />
+      </Group>
+      {loading && (
+        <Group gap="xs">
+          <Loader size="sm" />
+          <Text size="sm" c="dimmed">
+            Loading
+          </Text>
+        </Group>
+      )}
+    </Group>
+  );
+}

--- a/frontend/src/features/admin/components/AdminTopicManagement.tsx
+++ b/frontend/src/features/admin/components/AdminTopicManagement.tsx
@@ -209,13 +209,13 @@ export default function AdminTopicManagement() {
   return (
     <Stack gap="md">
       <Group justify="space-between" align="flex-end" wrap="wrap">
-        <Group gap="sm" wrap="wrap">
+        <Group gap="sm" wrap="wrap" style={{ flex: 1 }}>
           <TextInput
             label="New topic"
             placeholder="e.g. network"
             value={newTopic}
             onChange={(e) => setNewTopic(e.currentTarget.value)}
-            w={320}
+            w={{ base: "100%", sm: 320 }}
             error={inputError}
             onKeyDown={(e) => {
               if (e.key === "Enter") {

--- a/frontend/src/features/course/components/course/CourseBannerHeader.tsx
+++ b/frontend/src/features/course/components/course/CourseBannerHeader.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Container, Group, Stack, Text, Title } from "@mantine/core";
+import { Badge, Box, Container, Flex, Group, Stack, Text, Title } from "@mantine/core";
 import { IconArrowLeft } from "@tabler/icons-react";
 import Link from "next/link";
 import { CourseEnrollmentButton } from "@/src/features/course/components/enrollment/CourseEnrollmentButton";
@@ -91,8 +91,12 @@ export function CourseBannerHeader({
           )}
 
           {/* Title row */}
-          <div style={{ display: "flex", alignItems: "flex-start", gap: 24, flexWrap: "wrap" }}>
-            <div style={{ flex: "1 1 400px" }}>
+          <Flex
+            direction={{ base: "column", sm: "row" }}
+            align={{ base: "stretch", sm: "flex-start" }}
+            gap="lg"
+          >
+            <div style={{ flex: 1, minWidth: 0 }}>
               <Text
                 size="xs"
                 tt="uppercase"
@@ -135,7 +139,7 @@ export function CourseBannerHeader({
                 </Text>
               )}
             </div>
-            <div style={{ flexShrink: 0, paddingTop: 4 }}>
+            <div style={{ flexShrink: 0 }}>
               <CourseEnrollmentButton
                 courseId={courseId}
                 isEnrolled={isEnrolled}
@@ -144,7 +148,7 @@ export function CourseBannerHeader({
                 nextChallengeHref={nextChallengeHref}
               />
             </div>
-          </div>
+          </Flex>
         </Stack>
       </Box>
     </Container>

--- a/frontend/src/features/course/components/course/CourseJourneyCard.tsx
+++ b/frontend/src/features/course/components/course/CourseJourneyCard.tsx
@@ -2,6 +2,7 @@ import {
   Avatar,
   Box,
   Divider,
+  Flex,
   Group,
   Progress,
   Stack,
@@ -145,7 +146,7 @@ export function CourseJourneyCard({ labs, challenges, instructor }: CourseJourne
         overflow: "hidden",
       }}
     >
-      <div style={{ display: "flex", alignItems: "stretch" }}>
+      <Flex direction={{ base: "column", sm: "row" }} align="stretch">
         {/* —— Journey section —— */}
         <Stack gap="md" style={{ flex: 1, minWidth: 0, padding: "2rem" }}>
           <Group justify="space-between" align="center">
@@ -210,18 +211,17 @@ export function CourseJourneyCard({ labs, challenges, instructor }: CourseJourne
         {/* —— Instructor section (optional) —— */}
         {instructor && (
           <>
-            <div
-              style={{
-                width: 1,
-                background: "rgba(255,255,255,0.08)",
-                flexShrink: 0,
-              }}
+            <Box
+              visibleFrom="sm"
+              style={{ width: 1, background: "rgba(255,255,255,0.08)", flexShrink: 0 }}
             />
+            <Box hiddenFrom="sm" style={{ height: 1, background: "rgba(255,255,255,0.08)" }} />
             <Stack
               gap={12}
               justify="center"
+              w={{ base: "auto", sm: 240 }}
               style={{
-                flex: "0 0 220px",
+                flexShrink: 0,
                 padding: "2rem 1.75rem",
               }}
             >
@@ -258,7 +258,7 @@ export function CourseJourneyCard({ labs, challenges, instructor }: CourseJourne
             </Stack>
           </>
         )}
-      </div>
+      </Flex>
     </Box>
   );
 }

--- a/frontend/src/features/course/components/enrollment/CourseEnrollmentButton.tsx
+++ b/frontend/src/features/course/components/enrollment/CourseEnrollmentButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { startTransition, useState } from "react";
-import { Alert, Group, Stack, Text } from "@mantine/core";
+import { Alert, Flex, Group, Text } from "@mantine/core";
 import { IconArrowRight } from "@tabler/icons-react";
 import { useRouter } from "next/navigation";
 import { useApiClient } from "@/src/shared/lib/api/client";
@@ -73,7 +73,7 @@ export function CourseEnrollmentButton({
   }
 
   return (
-    <Stack gap="xs" align="flex-end">
+    <Flex direction="column" gap="xs" align={{ base: "flex-start", sm: "flex-end" }}>
       <Group gap="sm">
         {hasJoined ? (
           <AppButton
@@ -118,6 +118,6 @@ export function CourseEnrollmentButton({
           {joinError}
         </Alert>
       )}
-    </Stack>
+    </Flex>
   );
 }

--- a/frontend/src/features/course/components/enrollment/JoinCourseButton.tsx
+++ b/frontend/src/features/course/components/enrollment/JoinCourseButton.tsx
@@ -5,7 +5,13 @@ import type { ButtonProps } from "@mantine/core";
 import AppButton from "@/src/shared/components/AppButton";
 import JoinCourseModal from "@/src/features/course/components/enrollment/JoinCourseModal";
 
-export default function JoinCourseButton({ size = "xs" }: { size?: ButtonProps["size"] }) {
+export default function JoinCourseButton({
+  size = "xs",
+  fullWidth = false,
+}: {
+  size?: ButtonProps["size"];
+  fullWidth?: boolean;
+}) {
   const [opened, setOpened] = useState(false);
 
   return (
@@ -13,6 +19,7 @@ export default function JoinCourseButton({ size = "xs" }: { size?: ButtonProps["
       <AppButton
         tone="ghost"
         size={size}
+        fullWidth={fullWidth}
         onClick={() => setOpened(true)}
         leftSection={
           <span

--- a/frontend/src/features/user/components/UserMenu.tsx
+++ b/frontend/src/features/user/components/UserMenu.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Avatar, Group, Menu, Text, UnstyledButton } from "@mantine/core";
+import { Avatar, Box, Group, Menu, Text, UnstyledButton } from "@mantine/core";
 import Link from "next/link";
 import { ROLES } from "@/src/shared/lib/roles";
 
@@ -39,18 +39,18 @@ export default function UserMenu({ name, roles, image }: UserMenuProps) {
     <Menu shadow="md" width={220} position="bottom-end">
       <Menu.Target>
         <UnstyledButton aria-label="Open user menu" data-testid="user-menu-trigger">
-          <Group gap="sm">
+          <Group gap="sm" wrap="nowrap">
             <Avatar radius="xl" color={roleColor} src={image ?? undefined}>
               {initials}
             </Avatar>
-            <div style={{ lineHeight: 1.2 }}>
+            <Box visibleFrom="sm" style={{ lineHeight: 1.2 }}>
               <Text size="sm" fw={600} style={{ color: "#e2e8f0" }}>
                 {name}
               </Text>
               <Text size="xs" c={roleColor}>
                 {roleLabel}
               </Text>
-            </div>
+            </Box>
           </Group>
         </UnstyledButton>
       </Menu.Target>

--- a/frontend/src/shared/components/DashboardShell.tsx
+++ b/frontend/src/shared/components/DashboardShell.tsx
@@ -72,7 +72,11 @@ export default function DashboardShell({
 
           {/* Right side */}
           <Group gap="sm" wrap="nowrap">
-            {roles.includes(ROLES.STUDENT) && <JoinCourseButton />}
+            {roles.includes(ROLES.STUDENT) && (
+              <Box visibleFrom="sm">
+                <JoinCourseButton />
+              </Box>
+            )}
             <UserMenu name={name} roles={roles} image={image} />
           </Group>
         </Group>
@@ -85,6 +89,11 @@ export default function DashboardShell({
         }}
       >
         <DashboardNav roles={roles} onNavigate={close} />
+        {roles.includes(ROLES.STUDENT) && (
+          <Box hiddenFrom="sm" p="md">
+            <JoinCourseButton size="sm" fullWidth />
+          </Box>
+        )}
       </AppShellNavbar>
 
       <AppShellMain


### PR DESCRIPTION
Hide the user name beside the avatar on small screens and move the Join course button into the burger navigation. Stack the course detail header, journey and instructor sections on mobile. Rework the catalog filter into a full-width search with a separate actions row, and move Join course to the page header.

Replace the custom CSS-grid results table with a Mantine table inside a ScrollArea, wrap the admin course and lab tables in a ScrollArea, and make the admin search and config inputs use responsive widths.

Extract the duplicated admin list search bar into a shared AdminListSearch component.