### PR TITLE
Refactor/frontend openapi client

### DIFF
--- a/frontend/src/app/dashboard/instructor/[id]/page.tsx
+++ b/frontend/src/app/dashboard/instructor/[id]/page.tsx
@@ -56,6 +56,7 @@ import {
   type CourseLabEntry,
 } from "@/src/features/course/components/management/CourseLabManager";
 import { updateCourseLabs } from "@/src/features/course/actions/labs";
+import { useApiClient } from "@/src/shared/lib/api/client";
 import BadgeDesigner, { type BadgeConfig } from "@/src/features/badge/components/BadgeDesigner";
 
 const OWNER_ROLE: InstructorRoleEnum = "OWNER";
@@ -76,6 +77,7 @@ export default function EditCourse() {
   const router = useRouter();
   const params = useParams<{ id: string }>();
   const courseId = params.id;
+  const client = useApiClient();
   const { data: session } = useSession();
   const currentUserId = session?.userId;
 
@@ -242,17 +244,18 @@ export default function EditCourse() {
     }
 
     if (badgeConfig) {
-      await fetch(`/api/backend/api/v1/courses/${courseId}/badge`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          primaryColor: badgeConfig.primaryColor,
-          textColor: badgeConfig.textColor,
-          template: badgeConfig.template,
-          badgeIcon: badgeConfig.badgeIcon,
-          badgeEnabled: badgeConfig.badgeEnabled,
-        }),
-      }).catch(() => {});
+      await client
+        .PUT("/api/v1/courses/{courseId}/badge", {
+          params: { path: { courseId } },
+          body: {
+            primaryColor: badgeConfig.primaryColor,
+            textColor: badgeConfig.textColor,
+            template: badgeConfig.template,
+            badgeIcon: badgeConfig.badgeIcon,
+            badgeEnabled: badgeConfig.badgeEnabled,
+          },
+        })
+        .catch(() => {});
     }
 
     setInviteCode(result.data.inviteCode ?? null);

--- a/frontend/src/app/dashboard/instructor/[id]/results/page.tsx
+++ b/frontend/src/app/dashboard/instructor/[id]/results/page.tsx
@@ -33,6 +33,8 @@ import {
   IconUsers,
 } from "@tabler/icons-react";
 import { fetchCourse } from "@/src/features/course/actions/courses";
+import { useApiClient } from "@/src/shared/lib/api/client";
+import { apiErrorText } from "@/src/shared/lib/api";
 import {
   type CourseLabSubmissionEntryDto,
   type CourseLabChallengeSubmissionDetailDto,
@@ -220,6 +222,7 @@ export default function CourseResultsPage() {
   const router = useRouter();
   const params = useParams<{ id: string }>();
   const courseId = params.id;
+  const client = useApiClient();
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -242,16 +245,17 @@ export default function CourseResultsPage() {
       try {
         setLoading(true);
         setError(null);
-        const [courseResult, subRes] = await Promise.all([
+        const [courseResult, subResult] = await Promise.all([
           fetchCourse(courseId),
-          fetch(`/api/backend/api/v1/courses/${encodeURIComponent(courseId)}/submissions`, {
-            cache: "no-store",
+          client.GET("/api/v1/courses/{id}/submissions", {
+            params: { path: { id: courseId } },
           }),
         ]);
         if (courseResult.success) setCourseTitle(courseResult.data.title);
-        if (!subRes.ok) throw new Error((await subRes.text()) || subRes.statusText);
-        const json = (await subRes.json()) as CourseLabSubmissionsResponseDto;
-        if (!cancelled) setData(json);
+        if (subResult.error || !subResult.data) {
+          throw new Error(apiErrorText(subResult.error) ?? "Could not load submissions");
+        }
+        if (!cancelled) setData(subResult.data as CourseLabSubmissionsResponseDto);
       } catch (e) {
         if (!cancelled) setError((e as Error).message);
       } finally {
@@ -261,7 +265,7 @@ export default function CourseResultsPage() {
     return () => {
       cancelled = true;
     };
-  }, [courseId]);
+  }, [client, courseId]);
 
   const labs = useMemo<CourseLabResponseDto[]>(() => {
     if (!data) return [];
@@ -386,15 +390,14 @@ export default function CourseResultsPage() {
     try {
       setDetailLoading(true);
       setDetailError(null);
-      const res = await fetch(
-        `/api/backend/api/v1/courses/${encodeURIComponent(courseId)}/submissions/${encodeURIComponent(
-          participantId
-        )}/${encodeURIComponent(labId)}`,
-        { cache: "no-store" }
+      const { data, error } = await client.GET(
+        "/api/v1/courses/{id}/submissions/{participantId}/{labId}",
+        { params: { path: { id: courseId, participantId, labId } } }
       );
-      if (!res.ok) throw new Error((await res.text()) || res.statusText);
-      const json = (await res.json()) as CourseLabSubmissionDetailDto;
-      setDetail(json);
+      if (error || !data) {
+        throw new Error(apiErrorText(error) ?? "Could not load submission details");
+      }
+      setDetail(data as CourseLabSubmissionDetailDto);
     } catch (e) {
       setDetailError((e as Error).message);
       setDetail(null);

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/src/shared/lib/auth";
-import { getValidAccessToken } from "@/src/shared/lib/api/server";
+import { getApiClient } from "@/src/shared/lib/api/server";
 import { Alert, Badge, Button, Grid, GridCol, Group, Stack, Text, ThemeIcon } from "@mantine/core";
 import {
   IconArrowRight,
@@ -18,8 +18,6 @@ import { EmptyState } from "@/src/shared/components/EmptyState";
 import { CourseGrid } from "@/src/features/course/components/course/CourseGrid";
 import { fetchEnrolledCoursesOfLoggedInUser } from "@/src/features/course/actions/courses";
 import Link from "next/link";
-
-const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8080";
 
 type DeadlineItem = {
   courseId: string;
@@ -47,15 +45,10 @@ type RunningPod = {
 
 async function fetchCompletedLabsCount(): Promise<number | null> {
   try {
-    const accessToken = await getValidAccessToken();
-
-    const res = await fetch(`${BACKEND_URL}/api/v1/labs/my-completed-count`, {
-      cache: "no-store",
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    if (!res.ok) return null;
-    const json = (await res.json()) as { count?: number };
-    return typeof json.count === "number" ? json.count : null;
+    const client = await getApiClient();
+    const { data } = await client.GET("/api/v1/labs/my-completed-count");
+    const count = data?.count;
+    return typeof count === "number" ? count : null;
   } catch {
     return null;
   }
@@ -63,21 +56,9 @@ async function fetchCompletedLabsCount(): Promise<number | null> {
 
 async function fetchMyDeadlines(): Promise<DeadlineItem[]> {
   try {
-    const accessToken = await getValidAccessToken();
-
-    const res = await fetch(`${BACKEND_URL}/api/v1/courses/my-deadlines`, {
-      cache: "no-store",
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    if (!res.ok) return [];
-    const json = (await res.json()) as Array<{
-      courseId?: string;
-      courseTitle?: string;
-      labId?: string;
-      labTitle?: string;
-      dueAt?: string;
-    }>;
-    return (json ?? [])
+    const client = await getApiClient();
+    const { data } = await client.GET("/api/v1/courses/my-deadlines");
+    return (data ?? [])
       .filter((d) => d.courseId && d.labId && d.dueAt)
       .map((d) => ({
         courseId: String(d.courseId),
@@ -95,15 +76,9 @@ async function fetchMyDeadlines(): Promise<DeadlineItem[]> {
 
 async function fetchMyRunningPods(): Promise<RunningPod[]> {
   try {
-    const accessToken = await getValidAccessToken();
-
-    const res = await fetch(`${BACKEND_URL}/api/v1/lab-pods`, {
-      cache: "no-store",
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
-    if (!res.ok) return [];
-    const json = (await res.json()) as RunningPod[];
-    return Array.isArray(json) ? json : [];
+    const client = await getApiClient();
+    const { data } = await client.GET("/api/v1/lab-pods");
+    return (data ?? []) as RunningPod[];
   } catch {
     return [];
   }

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -19,6 +19,8 @@ import { CourseGrid } from "@/src/features/course/components/course/CourseGrid";
 import { fetchEnrolledCoursesOfLoggedInUser } from "@/src/features/course/actions/courses";
 import Link from "next/link";
 
+type ApiClient = Awaited<ReturnType<typeof getApiClient>>;
+
 type DeadlineItem = {
   courseId: string;
   courseTitle: string;
@@ -43,9 +45,8 @@ type RunningPod = {
   };
 };
 
-async function fetchCompletedLabsCount(): Promise<number | null> {
+async function fetchCompletedLabsCount(client: ApiClient): Promise<number | null> {
   try {
-    const client = await getApiClient();
     const { data } = await client.GET("/api/v1/labs/my-completed-count");
     const count = data?.count;
     return typeof count === "number" ? count : null;
@@ -54,9 +55,8 @@ async function fetchCompletedLabsCount(): Promise<number | null> {
   }
 }
 
-async function fetchMyDeadlines(): Promise<DeadlineItem[]> {
+async function fetchMyDeadlines(client: ApiClient): Promise<DeadlineItem[]> {
   try {
-    const client = await getApiClient();
     const { data } = await client.GET("/api/v1/courses/my-deadlines");
     return (data ?? [])
       .filter((d) => d.courseId && d.labId && d.dueAt)
@@ -74,9 +74,8 @@ async function fetchMyDeadlines(): Promise<DeadlineItem[]> {
   }
 }
 
-async function fetchMyRunningPods(): Promise<RunningPod[]> {
+async function fetchMyRunningPods(client: ApiClient): Promise<RunningPod[]> {
   try {
-    const client = await getApiClient();
     const { data } = await client.GET("/api/v1/lab-pods");
     return (data ?? []) as RunningPod[];
   } catch {
@@ -211,11 +210,12 @@ export default async function Home() {
   const name = session?.user?.name ?? "there";
   const firstName = name.split(" ")[0];
   const userId = session?.userId ?? undefined;
+  const client = await getApiClient();
   const result = await fetchEnrolledCoursesOfLoggedInUser(0, 3);
   const [deadlines, completedLabsCount, runningPods] = await Promise.all([
-    fetchMyDeadlines(),
-    fetchCompletedLabsCount(),
-    fetchMyRunningPods(),
+    fetchMyDeadlines(client),
+    fetchCompletedLabsCount(client),
+    fetchMyRunningPods(client),
   ]);
 
   const today = new Date();

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -77,7 +77,28 @@ async function fetchMyDeadlines(client: ApiClient): Promise<DeadlineItem[]> {
 async function fetchMyRunningPods(client: ApiClient): Promise<RunningPod[]> {
   try {
     const { data } = await client.GET("/api/v1/lab-pods");
-    return (data ?? []) as RunningPod[];
+    // Filter entries that don't carry the required pod identity — the UI reads
+    // `item.pod.status` and would crash on undefined nested data.
+    return (data ?? []).flatMap((dto) => {
+      if (typeof dto.labId !== "string" || !dto.pod || typeof dto.pod.status !== "string") {
+        return [];
+      }
+      return [
+        {
+          labId: dto.labId,
+          labTitle: dto.labTitle,
+          courseId: dto.courseId,
+          courseTitle: dto.courseTitle,
+          pod: {
+            status: dto.pod.status as PodStatusEnum,
+            podName: dto.pod.podName,
+            appUrl: dto.pod.appUrl,
+            createdAt: dto.pod.createdAt,
+            expiresAt: dto.pod.expiresAt,
+          },
+        },
+      ];
+    });
   } catch {
     return [];
   }

--- a/frontend/src/app/dashboard/profile/page.tsx
+++ b/frontend/src/app/dashboard/profile/page.tsx
@@ -6,6 +6,8 @@ import { Avatar, Group, Stack, Text, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { notifications } from "@mantine/notifications";
 import { useAsyncAction } from "@/src/shared/hooks/useAsyncAction";
+import { useApiClient } from "@/src/shared/lib/api/client";
+import { apiErrorText } from "@/src/shared/lib/api";
 import { httpUrlValidator } from "@/src/shared/lib/validation";
 import PageHeader from "@/src/shared/components/PageHeader";
 import AppButton from "@/src/shared/components/AppButton";
@@ -33,6 +35,7 @@ export const dynamic = "force-dynamic";
 
 export default function ProfilePage() {
   const router = useRouter();
+  const client = useApiClient();
   const [loadingProfile, setLoadingProfile] = useState(true);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [statusMessage, setStatusMessage] = useState<{
@@ -66,12 +69,11 @@ export default function ProfilePage() {
     setLoadingProfile(true);
     try {
       setStatusMessage(null);
-      const res = await fetch("/api/backend/api/v1/users/me/profile", { cache: "no-store" });
-      if (!res.ok) {
-        throw new Error(await safeErrorMessage(res));
+      const { data, error } = await client.GET("/api/v1/users/me/profile");
+      if (error || !data) {
+        throw new Error(apiErrorText(error) ?? "Could not load profile");
       }
-      const data = (await res.json()) as UserProfile;
-      setProfile(data);
+      setProfile(data as UserProfile);
       formRef.current.setValues({
         firstName: data.firstName ?? "",
         lastName: data.lastName ?? "",
@@ -91,7 +93,7 @@ export default function ProfilePage() {
     } finally {
       setLoadingProfile(false);
     }
-  }, []);
+  }, [client]);
 
   useEffect(() => {
     void loadProfile();
@@ -107,15 +109,11 @@ export default function ProfilePage() {
         pictureUrl: values.pictureUrl?.trim() || undefined,
       };
 
-      const res = await fetch("/api/backend/api/v1/users/me/profile", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) {
-        throw new Error(await safeErrorMessage(res));
+      const { data, error } = await client.PUT("/api/v1/users/me/profile", { body: payload });
+      if (error || !data) {
+        throw new Error(apiErrorText(error) ?? "Could not update profile");
       }
-      return (await res.json()) as UserProfile;
+      return data as UserProfile;
     },
     {
       id: "user-profile-save",
@@ -215,13 +213,4 @@ export default function ProfilePage() {
       </SurfaceCard>
     </Stack>
   );
-}
-
-async function safeErrorMessage(res: Response): Promise<string> {
-  try {
-    const data = (await res.json()) as { error?: string };
-    return data?.error || res.statusText || `HTTP ${res.status}`;
-  } catch {
-    return res.statusText || `HTTP ${res.status}`;
-  }
 }

--- a/frontend/src/features/admin/components/AdminChallengeManagement.tsx
+++ b/frontend/src/features/admin/components/AdminChallengeManagement.tsx
@@ -23,7 +23,8 @@ import { cleanText, formatDate, wrapTextStyle } from "@/src/features/admin/lib/a
 import AdminListSearch from "@/src/features/admin/components/AdminListSearch";
 import AppButton from "@/src/shared/components/AppButton";
 import MyEditor from "@/src/shared/components/MyEditor";
-import { readBackendError } from "@/src/shared/lib/readBackendError";
+import { useApiClient } from "@/src/shared/lib/api/client";
+import { apiErrorText } from "@/src/shared/lib/api";
 import { slugify } from "@/src/shared/lib/utils";
 import { toUserFriendlyBackendError } from "@/src/shared/lib/userFriendlyBackendError";
 
@@ -49,6 +50,7 @@ type AdminLabListItem = {
 const PAGE_SIZE = 10;
 
 export default function AdminChallengeManagement() {
+  const client = useApiClient();
   const {
     query,
     onQueryChange,
@@ -124,20 +126,18 @@ export default function AdminChallengeManagement() {
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch(`/api/backend/api/admin/labs/${selected.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      const { error, response } = await client.PUT("/api/admin/labs/{id}", {
+        params: { path: { id: selected.id } },
+        body: {
           title: values.title.trim(),
-          description: cleanText(values.description),
+          description: cleanText(values.description) ?? undefined,
           status: values.status,
           difficulty: values.difficulty,
-        }),
+        },
       });
-      if (!res.ok) {
-        const raw = await readBackendError(res);
-        const msg = toUserFriendlyBackendError(raw);
-        const color = res.status >= 500 ? "red" : "orange";
+      if (error || !response.ok) {
+        const msg = toUserFriendlyBackendError(apiErrorText(error));
+        const color = response.status >= 500 ? "red" : "orange";
         showToast(color, "Failed to update lab", msg ?? "Please try again.");
         return;
       }
@@ -156,13 +156,12 @@ export default function AdminChallengeManagement() {
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch(`/api/backend/api/admin/labs/${selected.id}`, {
-        method: "DELETE",
+      const { error, response } = await client.DELETE("/api/admin/labs/{id}", {
+        params: { path: { id: selected.id } },
       });
-      if (!res.ok) {
-        const raw = await readBackendError(res);
-        const msg = toUserFriendlyBackendError(raw);
-        const color = res.status >= 500 ? "red" : "orange";
+      if (error || !response.ok) {
+        const msg = toUserFriendlyBackendError(apiErrorText(error));
+        const color = response.status >= 500 ? "red" : "orange";
         showToast(color, "Failed to delete lab", msg ?? "Please try again.");
         return;
       }

--- a/frontend/src/features/admin/components/AdminCourseManagement.tsx
+++ b/frontend/src/features/admin/components/AdminCourseManagement.tsx
@@ -25,7 +25,8 @@ import AdminListSearch from "@/src/features/admin/components/AdminListSearch";
 import AppButton from "@/src/shared/components/AppButton";
 import { useCourseTopicOptions } from "@/src/features/course/hooks/useCourseTopicOptions";
 import MyEditor from "@/src/shared/components/MyEditor";
-import { readBackendError } from "@/src/shared/lib/readBackendError";
+import { useApiClient } from "@/src/shared/lib/api/client";
+import { apiErrorText } from "@/src/shared/lib/api";
 import { slugify } from "@/src/shared/lib/utils";
 import {
   COURSE_SHORT_DESCRIPTION_MAX_CHARS,
@@ -52,6 +53,7 @@ type AdminCourseListItem = {
 const PAGE_SIZE = 10;
 
 export default function AdminCourseManagement() {
+  const client = useApiClient();
   const topicOptions = useCourseTopicOptions();
   const {
     query,
@@ -132,27 +134,26 @@ export default function AdminCourseManagement() {
     setError(null);
     try {
       const normalizedShortDescription = normalizeShortDescription(values.shortDescription);
-      const res = await fetch(`/api/backend/api/admin/courses/${selected.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      const { error, response } = await client.PUT("/api/admin/courses/{id}", {
+        params: { path: { id: selected.id } },
+        body: {
           title: values.title.trim(),
-          description: cleanText(values.description),
-          shortDescription: cleanText(normalizedShortDescription),
+          description: cleanText(values.description) ?? "",
+          shortDescription: cleanText(normalizedShortDescription) ?? "",
           status: values.status,
-          topic: cleanText(values.topic),
-          imageUrl: cleanText(values.imageUrl),
-        }),
+          topic: cleanText(values.topic) ?? undefined,
+          imageUrl: cleanText(values.imageUrl) ?? undefined,
+        },
       });
-      if (!res.ok) {
-        const raw = await readBackendError(res);
+      if (error || !response.ok) {
+        const raw = apiErrorText(error);
         const msgLower = raw?.toLowerCase() ?? "";
         if (msgLower.includes("invalid topic")) {
           showToast("orange", "Invalid topic", "Please select a topic from the list.");
           return;
         }
         const msg = toUserFriendlyBackendError(raw);
-        const color = res.status >= 500 ? "red" : "orange";
+        const color = response.status >= 500 ? "red" : "orange";
         showToast(color, "Failed to update course", msg ?? "Please try again.");
         return;
       }
@@ -171,13 +172,12 @@ export default function AdminCourseManagement() {
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch(`/api/backend/api/admin/courses/${selected.id}`, {
-        method: "DELETE",
+      const { error, response } = await client.DELETE("/api/admin/courses/{id}", {
+        params: { path: { id: selected.id } },
       });
-      if (!res.ok) {
-        const raw = await readBackendError(res);
-        const msg = toUserFriendlyBackendError(raw);
-        const color = res.status >= 500 ? "red" : "orange";
+      if (error || !response.ok) {
+        const msg = toUserFriendlyBackendError(apiErrorText(error));
+        const color = response.status >= 500 ? "red" : "orange";
         showToast(color, "Failed to delete course", msg ?? "Please try again.");
         return;
       }

--- a/frontend/src/features/admin/components/AdminTopicManagement.tsx
+++ b/frontend/src/features/admin/components/AdminTopicManagement.tsx
@@ -5,7 +5,8 @@ import { ActionIcon, Group, Loader, Stack, Table, Text, TextInput } from "@manti
 import { notifications } from "@mantine/notifications";
 import { IconPlus, IconTrash } from "@tabler/icons-react";
 import AppButton from "@/src/shared/components/AppButton";
-import { readBackendError } from "@/src/shared/lib/readBackendError";
+import { useApiClient } from "@/src/shared/lib/api/client";
+import { apiErrorText } from "@/src/shared/lib/api";
 import { toUserFriendlyBackendError } from "@/src/shared/lib/userFriendlyBackendError";
 import { slugify } from "@/src/shared/lib/utils";
 import { ConfirmModal } from "@/src/shared/components/ConfirmModal";
@@ -15,6 +16,7 @@ const MAX_TOPIC_LENGTH = 24;
 const TOPIC_PATTERN = /^[A-Za-z][A-Za-z0-9-]*$/;
 
 export default function AdminTopicManagement() {
+  const client = useApiClient();
   const [topics, setTopics] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,20 +45,19 @@ export default function AdminTopicManagement() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/api/backend/api/admin/topics", { method: "GET" });
-      if (!res.ok) {
-        const msg = toUserFriendlyBackendError(await readBackendError(res));
+      const { data, error } = await client.GET("/api/admin/topics");
+      if (error) {
+        const msg = toUserFriendlyBackendError(apiErrorText(error));
         setError(`Failed to load topics.${msg ? ` ${msg}` : ""}`);
         return;
       }
-      const data = (await res.json()) as string[];
-      setTopics(Array.isArray(data) ? data : []);
+      setTopics(data ?? []);
     } catch {
       setError("Failed to load topics");
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [client]);
 
   useEffect(() => {
     void loadTopics();
@@ -108,13 +109,9 @@ export default function AdminTopicManagement() {
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch("/api/backend/api/admin/topics", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ value }),
-      });
-      if (!res.ok) {
-        const msg = await readBackendError(res);
+      const { error } = await client.POST("/api/admin/topics", { body: { value } });
+      if (error) {
+        const msg = apiErrorText(error);
         const msgLower = msg?.toLowerCase() ?? "";
         if (msgLower.includes("already exists")) {
           showToast(
@@ -183,15 +180,14 @@ export default function AdminTopicManagement() {
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch(`/api/backend/api/admin/topics/${encodeURIComponent(selected)}`, {
-        method: "DELETE",
+      const { error } = await client.DELETE("/api/admin/topics/{value}", {
+        params: { path: { value: selected } },
       });
-      if (!res.ok) {
-        const msg = await readBackendError(res);
+      if (error) {
         showToast(
           "red",
           "Failed to delete topic",
-          toUserFriendlyBackendError(msg) ?? "Please try again."
+          toUserFriendlyBackendError(apiErrorText(error)) ?? "Please try again."
         );
         return;
       }

--- a/frontend/src/features/admin/components/AdminUserManagement.tsx
+++ b/frontend/src/features/admin/components/AdminUserManagement.tsx
@@ -19,6 +19,8 @@ import {
 import { useForm } from "@mantine/form";
 import { notifications } from "@mantine/notifications";
 import AppButton from "@/src/shared/components/AppButton";
+import { useApiClient } from "@/src/shared/lib/api/client";
+import { apiErrorText } from "@/src/shared/lib/api";
 
 type CreateUserPayload = {
   email: string;
@@ -58,6 +60,7 @@ type AdminActiveSessionResponse = {
 
 export default function AdminUserManagement({ keycloakAdminUrl }: { keycloakAdminUrl?: string }) {
   const router = useRouter();
+  const client = useApiClient();
   const [created, setCreated] = useState<CreateUserResponse | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
   const [listQuery, setListQuery] = useState("");
@@ -94,31 +97,30 @@ export default function AdminUserManagement({ keycloakAdminUrl }: { keycloakAdmi
     },
   });
 
-  const loadUsers = useCallback(async (queryValue: string) => {
-    try {
-      setLoadingUsers(true);
-      const query = queryValue.trim();
-      const url = new URL("/api/backend/api/admin/users/directory", window.location.origin);
-      if (query) url.searchParams.set("q", query);
-      url.searchParams.set("first", "0");
-      url.searchParams.set("max", "50");
-
-      const res = await fetch(url.toString(), { cache: "no-store" });
-      if (!res.ok) {
-        throw new Error(await safeErrorMessage(res));
+  const loadUsers = useCallback(
+    async (queryValue: string) => {
+      try {
+        setLoadingUsers(true);
+        const query = queryValue.trim();
+        const { data, error } = await client.GET("/api/admin/users/directory", {
+          params: { query: { q: query || undefined, first: 0, max: 50 } },
+        });
+        if (error) {
+          throw new Error(apiErrorText(error) ?? "Failed to load users");
+        }
+        setUsers((data ?? []) as AdminUserListResponse);
+      } catch (e) {
+        notifications.show({
+          title: "Error",
+          message: "Failed to load users: " + (e as Error).message,
+          color: "red",
+        });
+      } finally {
+        setLoadingUsers(false);
       }
-      const data = (await res.json()) as AdminUserListResponse;
-      setUsers(data);
-    } catch (e) {
-      notifications.show({
-        title: "Error",
-        message: "Failed to load users: " + (e as Error).message,
-        color: "red",
-      });
-    } finally {
-      setLoadingUsers(false);
-    }
-  }, []);
+    },
+    [client]
+  );
 
   const formatEpoch = (value?: number) => {
     if (!value) return "-";
@@ -164,18 +166,14 @@ export default function AdminUserManagement({ keycloakAdminUrl }: { keycloakAdmi
         pictureUrl: values.pictureUrl?.trim() || undefined,
       };
 
-      const res = await fetch("/api/backend/api/admin/users", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+      const { data, error } = await client.POST("/api/admin/users", {
+        body: payload,
         signal: abortController.signal,
       });
-      if (!res.ok) {
-        const msg = await safeErrorMessage(res);
-        throw new Error(msg);
+      if (error || !data) {
+        throw new Error(apiErrorText(error) ?? "Failed to create user");
       }
-      const data = (await res.json()) as CreateUserResponse;
-      setCreated(data);
+      setCreated(data as CreateUserResponse);
 
       if (slowNotificationShown) {
         notifications.update({
@@ -230,10 +228,9 @@ export default function AdminUserManagement({ keycloakAdminUrl }: { keycloakAdmi
   const loadActiveSessions = async () => {
     try {
       setLoadingActiveSessions(true);
-      const res = await fetch("/api/backend/api/admin/sessions", { cache: "no-store" });
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
-      const data = (await res.json()) as AdminActiveSessionResponse;
-      setActiveSessions(data);
+      const { data, error } = await client.GET("/api/admin/sessions");
+      if (error) throw new Error(apiErrorText(error) ?? "Failed to load active sessions");
+      setActiveSessions((data ?? []) as AdminActiveSessionResponse);
     } catch (e) {
       notifications.show({
         title: "Error",
@@ -250,10 +247,10 @@ export default function AdminUserManagement({ keycloakAdminUrl }: { keycloakAdmi
     if (!id) return;
     try {
       setLoggingOutSessionId(id);
-      const res = await fetch(`/api/backend/api/admin/sessions/${encodeURIComponent(id)}`, {
-        method: "DELETE",
+      const { error } = await client.DELETE("/api/admin/sessions/{sessionId}", {
+        params: { path: { sessionId: id } },
       });
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
+      if (error) throw new Error(apiErrorText(error) ?? "Failed to logout session");
       notifications.show({ title: "Done", message: "Session logged out.", color: "green" });
       void loadActiveSessions();
     } catch (e) {
@@ -741,13 +738,4 @@ export default function AdminUserManagement({ keycloakAdminUrl }: { keycloakAdmi
       </Tabs.Panel>
     </Tabs>
   );
-}
-
-async function safeErrorMessage(res: Response): Promise<string> {
-  try {
-    const data = (await res.json()) as { error?: string; message?: string };
-    return data?.error || data?.message || res.statusText || `HTTP ${res.status}`;
-  } catch {
-    return res.statusText || `HTTP ${res.status}`;
-  }
 }

--- a/frontend/src/features/admin/components/AdminUserManagement.tsx
+++ b/frontend/src/features/admin/components/AdminUserManagement.tsx
@@ -108,7 +108,21 @@ export default function AdminUserManagement({ keycloakAdminUrl }: { keycloakAdmi
         if (error) {
           throw new Error(apiErrorText(error) ?? "Failed to load users");
         }
-        setUsers((data ?? []) as AdminUserListResponse);
+        // The schema marks most DTO fields as optional. Map to the internal
+        // shape so the UI does not depend on enabled/provisioned being undefined.
+        const safe: AdminUserListResponse = (data ?? []).flatMap((dto) =>
+          typeof dto.id === "string"
+            ? [
+                {
+                  ...dto,
+                  id: dto.id,
+                  enabled: !!dto.enabled,
+                  provisioned: !!dto.provisioned,
+                },
+              ]
+            : []
+        );
+        setUsers(safe);
       } catch (e) {
         notifications.show({
           title: "Error",
@@ -173,7 +187,10 @@ export default function AdminUserManagement({ keycloakAdminUrl }: { keycloakAdmi
       if (error || !data) {
         throw new Error(apiErrorText(error) ?? "Failed to create user");
       }
-      setCreated(data as CreateUserResponse);
+      if (typeof data.userId !== "string" || typeof data.temporaryPassword !== "string") {
+        throw new Error("Server returned an incomplete create-user response");
+      }
+      setCreated({ userId: data.userId, temporaryPassword: data.temporaryPassword });
 
       if (slowNotificationShown) {
         notifications.update({
@@ -230,7 +247,10 @@ export default function AdminUserManagement({ keycloakAdminUrl }: { keycloakAdmi
       setLoadingActiveSessions(true);
       const { data, error } = await client.GET("/api/admin/sessions");
       if (error) throw new Error(apiErrorText(error) ?? "Failed to load active sessions");
-      setActiveSessions((data ?? []) as AdminActiveSessionResponse);
+      const safe: AdminActiveSessionResponse = (data ?? []).flatMap((s) =>
+        typeof s.sessionId === "string" ? [{ ...s, sessionId: s.sessionId }] : []
+      );
+      setActiveSessions(safe);
     } catch (e) {
       notifications.show({
         title: "Error",

--- a/frontend/src/features/admin/components/AdminUserProfile.tsx
+++ b/frontend/src/features/admin/components/AdminUserProfile.tsx
@@ -20,6 +20,8 @@ import {
 import { useForm } from "@mantine/form";
 import { notifications } from "@mantine/notifications";
 import AppButton from "@/src/shared/components/AppButton";
+import { useApiClient } from "@/src/shared/lib/api/client";
+import { apiErrorText } from "@/src/shared/lib/api";
 
 type AdminUserDetailResponse = {
   id: string;
@@ -43,6 +45,7 @@ type AdminUserDetailResponse = {
 const ALL_APP_ROLES = ["ROLE_STUDENT", "ROLE_INSTRUCTOR", "ROLE_ADMINISTRATOR"] as const;
 
 export default function AdminUserProfile({ userId }: { userId: string }) {
+  const client = useApiClient();
   const [loading, setLoading] = useState(true);
   const [user, setUser] = useState<AdminUserDetailResponse | null>(null);
   const [savingProfile, setSavingProfile] = useState(false);
@@ -112,12 +115,11 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
   const load = useCallback(async () => {
     try {
       setLoading(true);
-      const res = await fetch(`/api/backend/api/admin/users/${encodeURIComponent(userId)}`, {
-        cache: "no-store",
+      const { data, error } = await client.GET("/api/admin/users/{userId}", {
+        params: { path: { userId } },
       });
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
-      const data = (await res.json()) as AdminUserDetailResponse;
-      setUser(data);
+      if (error || !data) throw new Error(apiErrorText(error) ?? "Failed to load user");
+      setUser(data as AdminUserDetailResponse);
 
       profileFormRef.current.setValues({
         email: data.email ?? "",
@@ -144,7 +146,7 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
     } finally {
       setLoading(false);
     }
-  }, [userId]);
+  }, [client, userId]);
 
   useEffect(() => {
     void load();
@@ -173,20 +175,16 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
       setSavingProfile(true);
 
       const v = profileForm.getValues();
-      const payload: Record<string, unknown> = {
-        firstName: v.firstName.trim(),
-        lastName: v.lastName.trim(),
-        title: v.title.trim() || undefined,
-      };
-      const picture = v.pictureUrl.trim();
-      if (picture) payload.pictureUrl = picture;
-
-      const res = await fetch(`/api/backend/api/v1/users/${encodeURIComponent(userId)}/profile`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+      const { error } = await client.PUT("/api/v1/users/{userId}/profile", {
+        params: { path: { userId } },
+        body: {
+          firstName: v.firstName.trim(),
+          lastName: v.lastName.trim(),
+          title: v.title.trim() || undefined,
+          pictureUrl: v.pictureUrl.trim() || undefined,
+        },
       });
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
+      if (error) throw new Error(apiErrorText(error) ?? "Failed to update profile");
       notifications.show({ title: "Saved", message: "Profile updated.", color: "green" });
       await load();
     } catch (e) {
@@ -211,13 +209,11 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
     }
     try {
       setSavingRoles(true);
-      const payload = { roles: [rolesForm.getValues().role] };
-      const res = await fetch(`/api/backend/api/admin/users/${encodeURIComponent(userId)}/roles`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+      const { error } = await client.PUT("/api/admin/users/{userId}/roles", {
+        params: { path: { userId } },
+        body: { roles: [rolesForm.getValues().role] },
       });
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
+      if (error) throw new Error(apiErrorText(error) ?? "Failed to update roles");
       notifications.show({ title: "Saved", message: "Roles updated.", color: "green" });
       await load();
     } catch (e) {
@@ -242,11 +238,10 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
     }
     try {
       setSendingResetEmail(true);
-      const res = await fetch(
-        `/api/backend/api/admin/users/${encodeURIComponent(userId)}/password-reset-email`,
-        { method: "POST" }
-      );
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
+      const { error } = await client.POST("/api/admin/users/{userId}/password-reset-email", {
+        params: { path: { userId } },
+      });
+      if (error) throw new Error(apiErrorText(error) ?? "Failed to send reset email");
       notifications.show({ title: "Sent", message: "Reset email triggered.", color: "green" });
     } catch (e) {
       notifications.show({
@@ -277,19 +272,15 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
       setSettingPassword(true);
       setPasswordSuccess(null);
       passwordForm.clearFieldError("password");
-      const res = await fetch(
-        `/api/backend/api/admin/users/${encodeURIComponent(userId)}/password`,
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            password: passwordForm.getValues().password.trim(),
-            temporary: passwordTemporary,
-          }),
-        }
-      );
-      if (!res.ok) {
-        const raw = await safeErrorMessage(res);
+      const { error } = await client.PUT("/api/admin/users/{userId}/password", {
+        params: { path: { userId } },
+        body: {
+          password: passwordForm.getValues().password.trim(),
+          temporary: passwordTemporary,
+        },
+      });
+      if (error) {
+        const raw = apiErrorText(error) ?? "Keycloak rejected the password.";
         passwordForm.setFieldError("password", toFriendlyPasswordError(raw));
         return;
       }
@@ -318,13 +309,10 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
     }
     try {
       setProvisioningUser(true);
-      const res = await fetch(
-        `/api/backend/api/admin/users/${encodeURIComponent(userId)}/provision`,
-        {
-          method: "POST",
-        }
-      );
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
+      const { error } = await client.POST("/api/admin/users/{userId}/provision", {
+        params: { path: { userId } },
+      });
+      if (error) throw new Error(apiErrorText(error) ?? "Failed to provision user");
       notifications.show({ title: "Done", message: "Provisioned (if needed).", color: "green" });
       await load();
     } catch (e) {
@@ -341,13 +329,10 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
   const disable = async () => {
     try {
       setDisablingUser(true);
-      const res = await fetch(
-        `/api/backend/api/admin/users/${encodeURIComponent(userId)}/disable`,
-        {
-          method: "POST",
-        }
-      );
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
+      const { error } = await client.POST("/api/admin/users/{userId}/disable", {
+        params: { path: { userId } },
+      });
+      if (error) throw new Error(apiErrorText(error) ?? "Failed to disable user");
       notifications.show({ title: "Done", message: "User disabled.", color: "green" });
       await load();
     } catch (e) {
@@ -364,13 +349,10 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
   const restore = async () => {
     try {
       setRestoringUser(true);
-      const res = await fetch(
-        `/api/backend/api/admin/users/${encodeURIComponent(userId)}/restore`,
-        {
-          method: "POST",
-        }
-      );
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
+      const { error } = await client.POST("/api/admin/users/{userId}/restore", {
+        params: { path: { userId } },
+      });
+      if (error) throw new Error(apiErrorText(error) ?? "Failed to restore user");
       notifications.show({ title: "Done", message: "User restored.", color: "green" });
       await load();
     } catch (e) {
@@ -392,13 +374,10 @@ export default function AdminUserProfile({ userId }: { userId: string }) {
 
     try {
       setSoftDeletingUser(true);
-      const res = await fetch(
-        `/api/backend/api/admin/users/${encodeURIComponent(userId)}/soft-delete`,
-        {
-          method: "POST",
-        }
-      );
-      if (!res.ok) throw new Error(await safeErrorMessage(res));
+      const { error } = await client.POST("/api/admin/users/{userId}/soft-delete", {
+        params: { path: { userId } },
+      });
+      if (error) throw new Error(apiErrorText(error) ?? "Failed to soft-delete user");
       notifications.show({ title: "Done", message: "User soft-deleted.", color: "green" });
       await load();
     } catch (e) {
@@ -765,13 +744,4 @@ function toFriendlyPasswordError(raw: string): string {
   }
 
   return msg;
-}
-
-async function safeErrorMessage(res: Response): Promise<string> {
-  try {
-    const data = (await res.json()) as { error?: string; message?: string };
-    return data?.error || data?.message || res.statusText || `HTTP ${res.status}`;
-  } catch {
-    return res.statusText || `HTTP ${res.status}`;
-  }
 }

--- a/frontend/src/features/badge/components/BadgeDesigner.tsx
+++ b/frontend/src/features/badge/components/BadgeDesigner.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { ColorInput, Group, SimpleGrid, Stack, Switch, Text, Title } from "@mantine/core";
+import { useApiClient } from "@/src/shared/lib/api/client";
 import BadgeSvg from "./BadgeSvg";
 
 const BG_SWATCHES = [
@@ -90,6 +91,7 @@ function TemplateCard({
 }
 
 export default function BadgeDesigner({ courseId, onChange }: Props) {
+  const client = useApiClient();
   const [config, setConfig] = useState<BadgeConfig>({
     primaryColor: "#4f46e5",
     textColor: "#ffffff",
@@ -100,9 +102,10 @@ export default function BadgeDesigner({ courseId, onChange }: Props) {
   });
 
   useEffect(() => {
-    void fetch(`/api/backend/api/v1/courses/${courseId}/badge`)
-      .then((r) => r.json())
-      .then((data: BadgeConfig) => {
+    void client
+      .GET("/api/v1/courses/{courseId}/badge", { params: { path: { courseId } } })
+      .then(({ data }) => {
+        if (!data) return;
         const loaded: BadgeConfig = {
           primaryColor: data.primaryColor ?? "#4f46e5",
           textColor: data.textColor ?? "#ffffff",
@@ -115,7 +118,7 @@ export default function BadgeDesigner({ courseId, onChange }: Props) {
         onChange(loaded);
       })
       .catch(() => {});
-  }, [courseId, onChange]);
+  }, [client, courseId, onChange]);
 
   const update = (patch: Partial<BadgeConfig>) => {
     setConfig((prev) => {

--- a/frontend/src/features/badge/components/TrophyCabinet.tsx
+++ b/frontend/src/features/badge/components/TrophyCabinet.tsx
@@ -212,7 +212,34 @@ export default function TrophyCabinet({ opened, onClose, userName = "Student" }:
     if (!opened) return;
     void client
       .GET("/api/v1/users/me/badges")
-      .then(({ data }) => setBadges((data ?? []) as UserBadge[]))
+      .then(({ data }) => {
+        // Filter out badges missing required fields — the SVG renderer reads
+        // primaryColor/textColor with substring() and crashes on undefined.
+        const safe: UserBadge[] = (data ?? []).flatMap((dto) =>
+          typeof dto.badgeId === "string" &&
+          typeof dto.courseId === "string" &&
+          typeof dto.courseTitle === "string" &&
+          typeof dto.primaryColor === "string" &&
+          typeof dto.textColor === "string" &&
+          typeof dto.template === "number" &&
+          typeof dto.badgeIcon === "string" &&
+          typeof dto.earnedAt === "string"
+            ? [
+                {
+                  badgeId: dto.badgeId,
+                  courseId: dto.courseId,
+                  courseTitle: dto.courseTitle,
+                  primaryColor: dto.primaryColor,
+                  textColor: dto.textColor,
+                  template: dto.template,
+                  badgeIcon: dto.badgeIcon,
+                  earnedAt: dto.earnedAt,
+                },
+              ]
+            : []
+        );
+        setBadges(safe);
+      })
       .catch(() => setBadges([]));
   }, [client, opened]);
 

--- a/frontend/src/features/badge/components/TrophyCabinet.tsx
+++ b/frontend/src/features/badge/components/TrophyCabinet.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Button, Group, Loader, Modal, SimpleGrid, Stack, Text, Tooltip } from "@mantine/core";
 import { IconMedal, IconPrinter, IconTrophy } from "@tabler/icons-react";
+import { useApiClient } from "@/src/shared/lib/api/client";
 import BadgeSvg from "./BadgeSvg";
 
 type UserBadge = {
@@ -202,17 +203,18 @@ function printCertificate(badge: UserBadge, userName: string) {
   frame.srcdoc = html;
 }
 export default function TrophyCabinet({ opened, onClose, userName = "Student" }: Props) {
+  const client = useApiClient();
   const [badges, setBadges] = useState<UserBadge[] | null>(null);
   const isLoading = opened && badges === null;
   const badgeList = badges ?? [];
 
   useEffect(() => {
     if (!opened) return;
-    void fetch("/api/backend/api/v1/users/me/badges")
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data: UserBadge[]) => setBadges(data))
+    void client
+      .GET("/api/v1/users/me/badges")
+      .then(({ data }) => setBadges((data ?? []) as UserBadge[]))
       .catch(() => setBadges([]));
-  }, [opened]);
+  }, [client, opened]);
 
   return (
     <Modal

--- a/frontend/src/features/course/hooks/useCourseTopicOptions.ts
+++ b/frontend/src/features/course/hooks/useCourseTopicOptions.ts
@@ -1,12 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { readBackendError } from "@/src/shared/lib/readBackendError";
+import { useApiClient } from "@/src/shared/lib/api/client";
+import { apiErrorText } from "@/src/shared/lib/api";
 import { toUserFriendlyBackendError } from "@/src/shared/lib/userFriendlyBackendError";
 
 type TopicOption = { value: string; label: string };
 
 export function useCourseTopicOptions() {
+  const client = useApiClient();
   const [topics, setTopics] = useState<string[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -18,14 +20,13 @@ export function useCourseTopicOptions() {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch("/api/backend/api/v1/courses/topics", { method: "GET" });
-        if (!res.ok) {
-          const msg = toUserFriendlyBackendError(await readBackendError(res));
+        const { data, error: requestError } = await client.GET("/api/v1/courses/topics");
+        if (requestError) {
+          const msg = toUserFriendlyBackendError(apiErrorText(requestError));
           throw new Error(msg ?? "Failed to load topics");
         }
-        const data = (await res.json()) as string[];
         if (!cancelled) {
-          setTopics(Array.isArray(data) ? data : []);
+          setTopics(data ?? []);
         }
       } catch (e) {
         if (!cancelled) {
@@ -43,7 +44,7 @@ export function useCourseTopicOptions() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [client]);
 
   const options: TopicOption[] = useMemo(
     () => (topics ?? []).map((t) => ({ value: t, label: t })),

--- a/frontend/src/features/course/hooks/useDockerImageCheck.ts
+++ b/frontend/src/features/course/hooks/useDockerImageCheck.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { readBackendError } from "@/src/shared/lib/readBackendError";
+import { useApiClient } from "@/src/shared/lib/api/client";
+import { apiErrorText } from "@/src/shared/lib/api";
 import { DOCKER_IMAGE_PATTERN } from "@/src/features/course/constants/challengeConstants";
 
 export type DockerImageCheckStatus = "idle" | "checking" | "success" | "error";
@@ -15,6 +16,7 @@ export function useDockerImageCheck(image: string): {
   status: DockerImageCheckStatus;
   message: string | null;
 } {
+  const client = useApiClient();
   const trimmed = image.trim();
   const isCheckable = DOCKER_IMAGE_PATTERN.test(trimmed);
   const [result, setResult] = useState<DockerImageCheckResult | null>(null);
@@ -26,20 +28,22 @@ export function useDockerImageCheck(image: string): {
 
     const controller = new AbortController();
     const timeout = window.setTimeout(() => {
-      void fetch(`/api/backend/api/v1/labs/docker-image?image=${encodeURIComponent(trimmed)}`, {
-        method: "GET",
-        signal: controller.signal,
-      })
-        .then(async (res) => {
-          if (!res.ok) {
-            const error = await readBackendError(res);
-            throw new Error(error ?? "Public GHCR image is not reachable");
+      void client
+        .GET("/api/v1/labs/docker-image", {
+          params: { query: { image: trimmed } },
+          signal: controller.signal,
+        })
+        .then(({ data, error }) => {
+          if (controller.signal.aborted) return;
+          if (error) {
+            const message = apiErrorText(error) ?? "Public GHCR image is not reachable";
+            setResult({ image: trimmed, status: "error", message });
+            return;
           }
-          const json = (await res.json().catch(() => null)) as { message?: unknown } | null;
           setResult({
             image: trimmed,
             status: "success",
-            message: typeof json?.message === "string" ? json.message : "Public GHCR image found",
+            message: data?.message ?? "Public GHCR image found",
           });
         })
         .catch((error: unknown) => {
@@ -56,7 +60,7 @@ export function useDockerImageCheck(image: string): {
       window.clearTimeout(timeout);
       controller.abort();
     };
-  }, [isCheckable, trimmed]);
+  }, [client, isCheckable, trimmed]);
 
   if (!trimmed || !isCheckable) {
     return { status: "idle", message: null };

--- a/frontend/src/shared/components/TimeTracker.tsx
+++ b/frontend/src/shared/components/TimeTracker.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect } from "react";
+import { useApiClient } from "@/src/shared/lib/api/client";
+
+type ApiClient = ReturnType<typeof useApiClient>;
 
 const BASE_STORAGE_KEY = "istp_total_seconds_online";
 const SYNCED_STORAGE_KEY = "istp_synced_seconds_online";
@@ -17,7 +20,11 @@ function syncedKey(userId: string | null): string {
 }
 
 /** Sends the unsynced delta (currentTotal - lastSyncedTotal) to the backend. */
-async function syncToBackend(userId: string | null, keepalive = false): Promise<void> {
+async function syncToBackend(
+  client: ApiClient,
+  userId: string | null,
+  keepalive = false
+): Promise<void> {
   if (!userId) return;
   try {
     const current = Number(localStorage.getItem(storageKey(userId)) ?? "0");
@@ -25,13 +32,11 @@ async function syncToBackend(userId: string | null, keepalive = false): Promise<
     const delta = current - synced;
     if (delta <= 0) return;
     const secondsToSync = Math.min(delta, MAX_SYNC_SECONDS);
-    const res = await fetch("/api/backend/api/v1/users/me/online-time", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ seconds: secondsToSync }),
+    const { response } = await client.PATCH("/api/v1/users/me/online-time", {
+      body: { seconds: secondsToSync },
       keepalive,
     });
-    if (res.ok) {
+    if (response.ok) {
       localStorage.setItem(syncedKey(userId), String(synced + secondsToSync));
     }
   } catch {
@@ -40,12 +45,11 @@ async function syncToBackend(userId: string | null, keepalive = false): Promise<
 }
 
 /** Fetches the server-stored total and seeds localStorage if the server has a higher value. */
-async function seedFromServer(userId: string | null): Promise<void> {
+async function seedFromServer(client: ApiClient, userId: string | null): Promise<void> {
   if (!userId) return;
   try {
-    const res = await fetch("/api/backend/api/v1/users/me/profile", { cache: "no-store" });
-    if (!res.ok) return;
-    const data = (await res.json()) as { totalSecondsOnline?: number };
+    const { data } = await client.GET("/api/v1/users/me/profile");
+    if (!data) return;
     const serverTotal = typeof data.totalSecondsOnline === "number" ? data.totalSecondsOnline : 0;
     const localTotal = Number(localStorage.getItem(storageKey(userId)) ?? "0");
     if (serverTotal > localTotal) {
@@ -67,9 +71,11 @@ async function seedFromServer(userId: string | null): Promise<void> {
  * Periodically syncs the accumulated delta to the backend so time is account-based.
  */
 export default function TimeTracker({ userId }: { userId: string | null }) {
+  const client = useApiClient();
+
   useEffect(() => {
     // Seed from server on mount so we pick up time from other devices
-    void seedFromServer(userId);
+    void seedFromServer(client, userId);
 
     const key = storageKey(userId);
     let lastTick = Date.now();
@@ -87,7 +93,7 @@ export default function TimeTracker({ userId }: { userId: string | null }) {
     }, TICK_INTERVAL_MS);
 
     const syncInterval = setInterval(() => {
-      void syncToBackend(userId);
+      void syncToBackend(client, userId);
     }, SYNC_INTERVAL_MS);
 
     // Also save and sync on tab switch / close
@@ -102,7 +108,7 @@ export default function TimeTracker({ userId }: { userId: string | null }) {
         } catch {
           // ignore
         }
-        void syncToBackend(userId, true);
+        void syncToBackend(client, userId, true);
       } else {
         // tab became visible again — reset lastTick
         lastTick = Date.now();
@@ -123,9 +129,9 @@ export default function TimeTracker({ userId }: { userId: string | null }) {
       } catch {
         // ignore
       }
-      void syncToBackend(userId, true);
+      void syncToBackend(client, userId, true);
     };
-  }, [userId]);
+  }, [client, userId]);
 
   return null;
 }

--- a/frontend/src/shared/lib/api/index.ts
+++ b/frontend/src/shared/lib/api/index.ts
@@ -1,6 +1,18 @@
 import createClient from "openapi-fetch";
 import type { paths } from "./schema";
 
+/**
+ * Extracts a human-readable message from an openapi-fetch error payload.
+ * The backend returns errors as `{ error: string }` (ErrorDto).
+ */
+export function apiErrorText(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "error" in error) {
+    const value = (error as { error?: unknown }).error;
+    if (typeof value === "string") return value;
+  }
+  return undefined;
+}
+
 export function createApiClient(baseUrl: string, accessToken?: string) {
   const headers = new Headers();
   if (accessToken) {

--- a/frontend/src/shared/lib/api/index.ts
+++ b/frontend/src/shared/lib/api/index.ts
@@ -13,7 +13,7 @@ export function apiErrorText(error: unknown): string | undefined {
   return undefined;
 }
 
-export function createApiClient(baseUrl: string, accessToken?: string) {
+export function createApiClient(baseUrl: string, accessToken?: string, customFetch?: typeof fetch) {
   const headers = new Headers();
   if (accessToken) {
     headers.set("Authorization", `Bearer ${accessToken}`);
@@ -22,5 +22,6 @@ export function createApiClient(baseUrl: string, accessToken?: string) {
   return createClient<paths>({
     baseUrl,
     headers,
+    ...(customFetch ? { fetch: customFetch } : {}),
   });
 }

--- a/frontend/src/shared/lib/api/schema.d.ts
+++ b/frontend/src/shared/lib/api/schema.d.ts
@@ -12,6 +12,10 @@ export interface paths {
       cookie?: never;
     };
     get?: never;
+    /**
+     * Update a user's profile
+     * @description Updates another user's profile. Requires sufficient privileges over the target user.
+     */
     put: operations["updateUserProfile"];
     post?: never;
     delete?: never;
@@ -27,7 +31,15 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * Get my profile
+     * @description Returns the profile of the authenticated user.
+     */
     get: operations["getMyProfile"];
+    /**
+     * Update my profile
+     * @description Updates the authenticated user's name, title and profile picture.
+     */
     put: operations["updateMyProfile"];
     post?: never;
     delete?: never;
@@ -139,7 +151,15 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * Get a course badge configuration
+     * @description Returns the badge design configuration for a course.
+     */
     get: operations["getCourseBadgeConfig"];
+    /**
+     * Update a course badge configuration
+     * @description Updates the badge design for a course. Only instructors of the course may do this.
+     */
     put: operations["updateCourseBadgeConfig"];
     post?: never;
     delete?: never;
@@ -156,6 +176,10 @@ export interface paths {
       cookie?: never;
     };
     get?: never;
+    /**
+     * Update a user's role
+     * @description Normalises the user to a single application role and returns the updated user.
+     */
     put: operations["updateUserRole"];
     post?: never;
     delete?: never;
@@ -172,6 +196,10 @@ export interface paths {
       cookie?: never;
     };
     get?: never;
+    /**
+     * Set a user's password
+     * @description Sets a new (optionally temporary) password for the given user.
+     */
     put: operations["setUserPassword"];
     post?: never;
     delete?: never;
@@ -188,8 +216,16 @@ export interface paths {
       cookie?: never;
     };
     get?: never;
+    /**
+     * Update a lab
+     * @description Updates a lab's title, description, status and difficulty as an administrator.
+     */
     put: operations["updateChallenge"];
     post?: never;
+    /**
+     * Delete a lab
+     * @description Soft-deletes a lab so it is no longer visible to students or instructors.
+     */
     delete: operations["deleteChallenge"];
     options?: never;
     head?: never;
@@ -204,8 +240,16 @@ export interface paths {
       cookie?: never;
     };
     get?: never;
+    /**
+     * Update a course
+     * @description Updates a course's details, topic and visibility as an administrator.
+     */
     put: operations["updateCourse_1"];
     post?: never;
+    /**
+     * Delete a course
+     * @description Soft-deletes a course so it is no longer visible to students or instructors.
+     */
     delete: operations["deleteCourse_1"];
     options?: never;
     head?: never;
@@ -219,9 +263,25 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * Get the platform configuration
+     * @description Returns the current admin configuration. When none is stored yet, a response with kubeconfigUploaded=false and empty limits is returned.
+     */
     get: operations["getAdminConfig"];
+    /**
+     * Update the platform configuration
+     * @description Updates the pod resource limits and optionally replaces the kubeconfig. Omitting the kubeconfig keeps the previously stored one.
+     */
     put: operations["updateAdminConfig"];
+    /**
+     * Create the platform configuration
+     * @description Uploads a base64-encoded kubeconfig together with optional pod resource limits and stores the initial admin configuration.
+     */
     post: operations["uploadAndStoreAdminConfig"];
+    /**
+     * Delete the platform configuration
+     * @description Removes the stored admin configuration, including the kubeconfig.
+     */
     delete: operations["deleteAdminConfig"];
     options?: never;
     head?: never;
@@ -237,6 +297,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
+    /**
+     * Request a password reset email
+     * @description Triggers a Keycloak password reset email for the authenticated user's own account.
+     */
     post: operations["sendMyPasswordResetEmail"];
     delete?: never;
     options?: never;
@@ -335,9 +399,21 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * Get a lab pod status
+     * @description Returns the current status of the authenticated user's pod for the given lab.
+     */
     get: operations["getPod"];
     put?: never;
+    /**
+     * Start a lab pod
+     * @description Starts a pod for the given lab, or returns the existing pod if one is already running.
+     */
     post: operations["startPod"];
+    /**
+     * Stop a lab pod
+     * @description Stops and removes the authenticated user's pod for the given lab.
+     */
     delete: operations["stopPod"];
     options?: never;
     head?: never;
@@ -353,6 +429,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
+    /**
+     * Extend a lab pod
+     * @description Extends the time-to-live of the authenticated user's pod for the given lab.
+     */
     post: operations["extendPod"];
     delete?: never;
     options?: never;
@@ -467,8 +547,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List users
+     * @description Returns a paginated list of provisioned ISTP users, optionally filtered by a search query.
+     */
     get: operations["listUsers"];
     put?: never;
+    /**
+     * Create a user
+     * @description Creates a new Keycloak user and returns the generated user ID and temporary password.
+     */
     post: operations["createUser"];
     delete?: never;
     options?: never;
@@ -485,6 +573,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
+    /**
+     * Soft-delete a user
+     * @description Anonymises the user's email/username and disables the account to free the identifiers for reuse. Cannot be undone.
+     */
     post: operations["softDeleteUser"];
     delete?: never;
     options?: never;
@@ -501,6 +593,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
+    /**
+     * Restore a user
+     * @description Re-enables a previously disabled user account.
+     */
     post: operations["restoreUser"];
     delete?: never;
     options?: never;
@@ -517,6 +613,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
+    /**
+     * Provision a user
+     * @description Creates the ISTP database record for an existing Keycloak account. Idempotent.
+     */
     post: operations["provisionUser"];
     delete?: never;
     options?: never;
@@ -533,6 +633,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
+    /**
+     * Send a password reset email
+     * @description Triggers a Keycloak password reset email for the given user.
+     */
     post: operations["sendPasswordResetEmail"];
     delete?: never;
     options?: never;
@@ -549,6 +653,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
+    /**
+     * Log out a user
+     * @description Terminates all active sessions of the given user.
+     */
     post: operations["logoutUser"];
     delete?: never;
     options?: never;
@@ -565,6 +673,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
+    /**
+     * Disable a user
+     * @description Blocks the user from logging in and marks the account as disabled.
+     */
     post: operations["disableUser"];
     delete?: never;
     options?: never;
@@ -579,8 +691,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List course topics
+     * @description Returns all course topics currently configured on the platform.
+     */
     get: operations["listTopics"];
     put?: never;
+    /**
+     * Add a course topic
+     * @description Creates a new course topic that instructors can assign to their courses.
+     */
     post: operations["addTopic"];
     delete?: never;
     options?: never;
@@ -601,6 +721,10 @@ export interface paths {
     delete?: never;
     options?: never;
     head?: never;
+    /**
+     * Add online time
+     * @description Adds elapsed online time (in seconds) to the authenticated user's total.
+     */
     patch: operations["addOnlineTime"];
     trace?: never;
   };
@@ -611,6 +735,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List my badges
+     * @description Returns all badges earned by the authenticated user.
+     */
     get: operations["getMyBadges"];
     put?: never;
     post?: never;
@@ -627,6 +755,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List collaborator/instructor users
+     * @description Returns a paginated list of users eligible to be added as course collaborators, optionally filtered by a search query.
+     */
     get: operations["listCollaboratorUsers"];
     put?: never;
     post?: never;
@@ -643,6 +775,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List collaborator/instructor users
+     * @description Returns a paginated list of users eligible to be added as course collaborators, optionally filtered by a search query.
+     */
     get: operations["listCollaboratorUsers_1"];
     put?: never;
     post?: never;
@@ -759,6 +895,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List my running lab pods
+     * @description Returns all currently running lab pods owned by the authenticated user.
+     */
     get: operations["listMyPods"];
     put?: never;
     post?: never;
@@ -815,6 +955,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * Render a course badge as SVG
+     * @description Returns the course badge rendered as an SVG image.
+     */
     get: operations["getCourseBadgeSvg"];
     put?: never;
     post?: never;
@@ -931,6 +1075,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * Get a user
+     * @description Returns the full admin detail for one user.
+     */
     get: operations["getUser"];
     put?: never;
     post?: never;
@@ -947,6 +1095,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List a user's sessions
+     * @description Returns the active Keycloak sessions for one user.
+     */
     get: operations["listUserSessions"];
     put?: never;
     post?: never;
@@ -963,6 +1115,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List the user directory
+     * @description Returns Keycloak user directory entries, optionally filtered by a search query and paged via first/max offsets.
+     */
     get: operations["listUserDirectory"];
     put?: never;
     post?: never;
@@ -979,6 +1135,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List active sessions
+     * @description Returns all active Keycloak sessions for the configured application client.
+     */
     get: operations["listActiveSessions"];
     put?: never;
     post?: never;
@@ -995,6 +1155,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List labs
+     * @description Returns a paginated list of all labs on the platform, optionally filtered by a search query.
+     */
     get: operations["listChallenges"];
     put?: never;
     post?: never;
@@ -1011,6 +1175,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
+    /**
+     * List courses
+     * @description Returns a paginated list of all courses on the platform, optionally filtered by a search query.
+     */
     get: operations["listCourses_1"];
     put?: never;
     post?: never;
@@ -1070,6 +1238,10 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
+    /**
+     * Delete a course topic
+     * @description Removes a course topic and clears it from any courses that referenced it.
+     */
     delete: operations["deleteTopic"];
     options?: never;
     head?: never;
@@ -1086,6 +1258,10 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
+    /**
+     * Terminate a session
+     * @description Logs out a single active session by its session ID.
+     */
     delete: operations["logoutSession"];
     options?: never;
     head?: never;
@@ -1114,6 +1290,9 @@ export interface components {
       title?: string;
       /** Format: int64 */
       totalSecondsOnline?: number;
+    };
+    ErrorDto: {
+      error?: string;
     };
     ChallengeOptionRequestDto: {
       /** Format: uuid */
@@ -1204,9 +1383,6 @@ export interface components {
       createdAt?: string;
       /** Format: date-time */
       updatedAt?: string;
-    };
-    ErrorDto: {
-      error?: string;
     };
     UpdateCourseInstructorRequestDto: {
       /** Format: uuid */
@@ -1688,14 +1864,14 @@ export interface components {
       totalPages?: number;
       /** Format: int64 */
       totalElements?: number;
-      first?: boolean;
-      last?: boolean;
       /** Format: int32 */
       size?: number;
       content?: components["schemas"]["ListInstructorUserResponseDto"][];
       /** Format: int32 */
       number?: number;
       sort?: components["schemas"]["SortObject"];
+      first?: boolean;
+      last?: boolean;
       /** Format: int32 */
       numberOfElements?: number;
       pageable?: components["schemas"]["PageableObject"];
@@ -1707,9 +1883,9 @@ export interface components {
       sort?: components["schemas"]["SortObject"];
       /** Format: int32 */
       pageNumber?: number;
-      paged?: boolean;
       /** Format: int32 */
       pageSize?: number;
+      paged?: boolean;
       unpaged?: boolean;
     };
     SortObject: {
@@ -1743,14 +1919,14 @@ export interface components {
       totalPages?: number;
       /** Format: int64 */
       totalElements?: number;
-      first?: boolean;
-      last?: boolean;
       /** Format: int32 */
       size?: number;
       content?: components["schemas"]["ListLabResponseDto"][];
       /** Format: int32 */
       number?: number;
       sort?: components["schemas"]["SortObject"];
+      first?: boolean;
+      last?: boolean;
       /** Format: int32 */
       numberOfElements?: number;
       pageable?: components["schemas"]["PageableObject"];
@@ -1798,14 +1974,14 @@ export interface components {
       totalPages?: number;
       /** Format: int64 */
       totalElements?: number;
-      first?: boolean;
-      last?: boolean;
       /** Format: int32 */
       size?: number;
       content?: components["schemas"]["ListCourseResponseDto"][];
       /** Format: int32 */
       number?: number;
       sort?: components["schemas"]["SortObject"];
+      first?: boolean;
+      last?: boolean;
       /** Format: int32 */
       numberOfElements?: number;
       pageable?: components["schemas"]["PageableObject"];
@@ -1885,14 +2061,14 @@ export interface components {
       totalPages?: number;
       /** Format: int64 */
       totalElements?: number;
-      first?: boolean;
-      last?: boolean;
       /** Format: int32 */
       size?: number;
       content?: components["schemas"]["AdminUserListItemDto"][];
       /** Format: int32 */
       number?: number;
       sort?: components["schemas"]["SortObject"];
+      first?: boolean;
+      last?: boolean;
       /** Format: int32 */
       numberOfElements?: number;
       pageable?: components["schemas"]["PageableObject"];
@@ -1968,14 +2144,14 @@ export interface components {
       totalPages?: number;
       /** Format: int64 */
       totalElements?: number;
-      first?: boolean;
-      last?: boolean;
       /** Format: int32 */
       size?: number;
       content?: components["schemas"]["AdminLabListItemDto"][];
       /** Format: int32 */
       number?: number;
       sort?: components["schemas"]["SortObject"];
+      first?: boolean;
+      last?: boolean;
       /** Format: int32 */
       numberOfElements?: number;
       pageable?: components["schemas"]["PageableObject"];
@@ -2005,14 +2181,14 @@ export interface components {
       totalPages?: number;
       /** Format: int64 */
       totalElements?: number;
-      first?: boolean;
-      last?: boolean;
       /** Format: int32 */
       size?: number;
       content?: components["schemas"]["AdminCourseListItemDto"][];
       /** Format: int32 */
       number?: number;
       sort?: components["schemas"]["SortObject"];
+      first?: boolean;
+      last?: boolean;
       /** Format: int32 */
       numberOfElements?: number;
       pageable?: components["schemas"]["PageableObject"];
@@ -2042,13 +2218,40 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
+      /** @description Profile updated successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["UserDto"];
+        };
+      };
+      /** @description Invalid request data */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description User not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -2062,7 +2265,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Profile retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -2086,13 +2289,22 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
+      /** @description Profile updated successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["UserDto"];
+        };
+      };
+      /** @description Invalid request data */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -2451,13 +2663,22 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Badge configuration retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["CourseBadgeConfigDto"];
+        };
+      };
+      /** @description Course not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -2477,13 +2698,40 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
+      /** @description Badge configuration updated successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["CourseBadgeConfigDto"];
+        };
+      };
+      /** @description Invalid badge configuration */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Course not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -2503,13 +2751,31 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
+      /** @description Role updated successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["AdminUserDetailDto"];
+        };
+      };
+      /** @description Invalid role request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description User not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -2529,12 +2795,30 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Password set successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Keycloak rejected the password (e.g. password policy violation) */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -2553,12 +2837,30 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Lab updated successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Invalid request data */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Lab not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -2573,12 +2875,21 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Lab deleted successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Lab not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -2597,12 +2908,30 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Course updated successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Invalid request data */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Course not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -2617,12 +2946,21 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Course deleted successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Course not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -2635,7 +2973,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Configuration retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -2659,13 +2997,22 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
+      /** @description Configuration updated successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["AdminConfigResponse"];
+        };
+      };
+      /** @description Invalid base64 kubeconfig or file exceeds the 1 MB limit */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -2683,13 +3030,31 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Configuration created successfully */
+      201: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["AdminConfigResponse"];
+        };
+      };
+      /** @description Missing kubeconfig, invalid base64, or file exceeds the 1 MB limit */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Unexpected server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -2703,7 +3068,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Configuration deleted successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -2725,8 +3090,8 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Password reset email sent */
+      204: {
         headers: {
           [name: string]: unknown;
         };
@@ -2969,7 +3334,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Pod status retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -2991,13 +3356,31 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Pod already running */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["PodStatusResponse"];
+        };
+      };
+      /** @description Pod created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["PodStatusResponse"];
+        };
+      };
+      /** @description Kubernetes operation failed */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -3013,8 +3396,15 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Pod stopped successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description No pod found for the given lab */
+      404: {
         headers: {
           [name: string]: unknown;
         };
@@ -3033,13 +3423,22 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Pod extended successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["PodStatusResponse"];
+        };
+      };
+      /** @description Kubernetes operation failed */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -3282,7 +3681,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Users retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -3306,13 +3705,22 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
-      200: {
+      /** @description User created successfully */
+      201: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["AdminCreateUserResponseDto"];
+        };
+      };
+      /** @description Invalid request data */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -3328,12 +3736,21 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description User soft-deleted successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description User not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -3348,12 +3765,30 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description User restored successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description User not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description User is soft-deleted and cannot be restored */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -3368,13 +3803,31 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description User provisioned successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["AdminProvisionUserResponseDto"];
+        };
+      };
+      /** @description User not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description User is soft-deleted and cannot be provisioned */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -3390,12 +3843,21 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Password reset email sent */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Keycloak rejected the request */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -3410,12 +3872,21 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description User logged out successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Keycloak rejected the request */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -3430,12 +3901,21 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description User disabled successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description User not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -3448,7 +3928,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Topics retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -3472,7 +3952,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
+      /** @description Topic added successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -3481,6 +3961,24 @@ export interface operations {
           "*/*": {
             [key: string]: string;
           };
+        };
+      };
+      /** @description Invalid topic value */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Unexpected server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -3498,12 +3996,21 @@ export interface operations {
       };
     };
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Online time recorded successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Invalid request data */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };
@@ -3516,7 +4023,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Badges retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -3539,7 +4046,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Users retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -3562,7 +4069,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Users retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -3742,7 +4249,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Pods retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -3846,13 +4353,22 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Badge SVG rendered successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "image/svg+xml": string;
+        };
+      };
+      /** @description Course not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "image/svg+xml": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -4012,13 +4528,22 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description User found */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["AdminUserDetailDto"];
+        };
+      };
+      /** @description User not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -4034,13 +4559,22 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Sessions retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "*/*": components["schemas"]["KeycloakUserSessionRepresentation"][];
+        };
+      };
+      /** @description Keycloak rejected the request */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -4058,7 +4592,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description User directory retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -4078,7 +4612,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Active sessions retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -4101,7 +4635,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Labs retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -4124,7 +4658,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Courses retrieved successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -4214,7 +4748,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
+      /** @description Topic deleted successfully */
       200: {
         headers: {
           [name: string]: unknown;
@@ -4223,6 +4757,24 @@ export interface operations {
           "*/*": {
             [key: string]: string;
           };
+        };
+      };
+      /** @description Invalid topic value */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Topic not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
         };
       };
     };
@@ -4238,12 +4790,30 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Session terminated successfully */
+      204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Session ID is missing */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
+      };
+      /** @description Keycloak rejected the logout request */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorDto"];
+        };
       };
     };
   };

--- a/frontend/src/shared/lib/api/server.ts
+++ b/frontend/src/shared/lib/api/server.ts
@@ -8,6 +8,13 @@ import type { GetTokenParams } from "next-auth/jwt";
 
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8080";
 
+/**
+ * Server-side fetch that opts out of Next.js's request-deduplication / data
+ * cache. Dashboard data is per-user and request-scoped, so caching could
+ * serve stale or — worse — incorrectly shared data between users.
+ */
+const noStoreFetch: typeof fetch = (input, init) => fetch(input, { cache: "no-store", ...init });
+
 const COOKIE_CHUNK_SIZE = 4096 - 163;
 const SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
 
@@ -152,5 +159,5 @@ export async function getApiClient() {
   // Keep getServerSession() to preserve existing NextAuth behavior (callbacks, session state).
   await getServerSession(authOptions);
   const accessToken = await getValidAccessToken();
-  return createApiClient(BACKEND_URL, accessToken);
+  return createApiClient(BACKEND_URL, accessToken, noStoreFetch);
 }


### PR DESCRIPTION
Replace raw fetch() calls to /api/backend and ${BACKEND_URL} with the generated openapi-fetch client (getApiClient on the server, useApiClient in client components). Covers the dashboard server fetches, the docker-image / course-topics hooks, TimeTracker, BadgeDesigner, TrophyCabinet, the profile and results pages, the course edit page and all admin components.

Add a shared apiErrorText() helper to read the backend ErrorDto from openapi-fetch error payloads. The generic useAdminPagedList hook keeps a plain fetch because its endpoint is dynamic and cannot be expressed as a literal client path.