### PR TITLE
refactor(landing): wire up real GitHub and Issues links

### DIFF
--- a/frontend/src/features/landing/components/LandingFooter.tsx
+++ b/frontend/src/features/landing/components/LandingFooter.tsx
@@ -17,7 +17,7 @@ export default function LandingFooter() {
       }}
     >
       <Container size="xl" px={32}>
-        <SimpleGrid cols={{ base: 2, md: 4 }} spacing={40}>
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing={40}>
           <Stack gap={14}>
             <BrandLockup />
             <Text
@@ -39,12 +39,14 @@ export default function LandingFooter() {
               <Stack gap={10}>
                 {section.links.map((link) => (
                   <Anchor
-                    key={link}
-                    href="#"
+                    key={link.label}
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
                     underline="never"
                     style={{ fontSize: 14, color: INK_DIM }}
                   >
-                    {link}
+                    {link.label}
                   </Anchor>
                 ))}
               </Stack>

--- a/frontend/src/features/landing/components/LandingNav.tsx
+++ b/frontend/src/features/landing/components/LandingNav.tsx
@@ -10,7 +10,7 @@ const navLinks = [
   { label: "Features", href: "#bento" },
   { label: "Product", href: "#screens" },
   { label: "For Schools", href: "#cta" },
-  { label: "GitHub ↗", href: "https://github.com" },
+  { label: "GitHub ↗", href: "https://github.com/PM4-ISTP/PM4-IT24aWIN-ISTP" },
 ];
 
 export default function LandingNav() {

--- a/frontend/src/features/landing/content/footer.ts
+++ b/frontend/src/features/landing/content/footer.ts
@@ -1,16 +1,12 @@
-export type FooterSection = { title: string; links: string[] };
+export type FooterLink = { label: string; href: string };
+export type FooterSection = { title: string; links: FooterLink[] };
 
 export const FOOTER_SECTIONS: FooterSection[] = [
   {
     title: "Project",
-    links: ["GitHub", "Docs", "Issues", "Roadmap"],
-  },
-  {
-    title: "Community",
-    links: ["Contribute", "Code of Conduct"],
-  },
-  {
-    title: "For universities",
-    links: ["Self-hosting", "Authoring", "Contact"],
+    links: [
+      { label: "GitHub", href: "https://github.com/PM4-ISTP/PM4-IT24aWIN-ISTP" },
+      { label: "Issues", href: "https://github.com/PM4-ISTP/PM4-IT24aWIN-ISTP/issues" },
+    ],
   },
 ];


### PR DESCRIPTION
Replace placeholder hrefs in the landing footer and navbar with the actual repository URLs. Footer links now carry their own href via a typed FooterLink, and unused sections (Docs, Roadmap, Community, For universities) are removed until they have real targets.