### PR TITLE
fix: smoother course/lab edit flow for instructors

### DIFF
--- a/backend/src/main/java/com/pm4/istp/course/services/impl/CourseServiceImpl.java
+++ b/backend/src/main/java/com/pm4/istp/course/services/impl/CourseServiceImpl.java
@@ -1179,12 +1179,6 @@ public class CourseServiceImpl implements CourseService {
                 () -> new CourseNotFoundException(String.format(COURSE_NOT_FOUND_MSG, courseId)));
     verifyOwner(course, userId);
 
-    if (course.getStatus() != CourseStatusEnum.PRIVATE) {
-      throw new CourseAccessDeniedException(
-          String.format(
-              "Course '%s' is not private; invite code regeneration is disabled", courseId));
-    }
-
     course.setInviteCode(courseInviteCodeHelper.generateAndAssign(courseId));
     return course;
   }

--- a/backend/src/test/java/com/pm4/istp/course/CourseServiceImplTest.java
+++ b/backend/src/test/java/com/pm4/istp/course/CourseServiceImplTest.java
@@ -2001,7 +2001,10 @@ class CourseServiceImplTest {
   }
 
   @Test
-  void regenerateInviteCode_whenCourseIsNotPrivate_throwsCourseAccessDeniedException() {
+  void regenerateInviteCode_whenCourseIsNotPrivate_stillRegeneratesCode() {
+    // Owner can pre-generate an invite code before saving the visibility change to PRIVATE.
+    // updateCourse nulls the code again if the saved status is not PRIVATE, so the invariant
+    // "non-PRIVATE -> no inviteCode" is restored on the next save.
     UUID ownerId = UUID.randomUUID();
     UUID courseId = UUID.randomUUID();
 
@@ -2018,12 +2021,12 @@ class CourseServiceImplTest {
     course.addCourseInstructor(ownerRelation);
 
     when(courseRepository.findByIdAndDeletedAtIsNull(courseId)).thenReturn(Optional.of(course));
+    when(courseInviteCodeHelper.generateAndAssign(courseId)).thenReturn("NEWCOD");
 
-    assertThatThrownBy(() -> courseService.regenerateInviteCode(courseId, ownerId))
-        .isInstanceOf(CourseAccessDeniedException.class)
-        .hasMessageContaining("not private");
+    Course result = courseService.regenerateInviteCode(courseId, ownerId);
 
-    verify(courseInviteCodeHelper, never()).generateAndAssign(any());
+    verify(courseInviteCodeHelper).generateAndAssign(courseId);
+    assertThat(result.getInviteCode()).isEqualTo("NEWCOD");
   }
 
   @Test

--- a/frontend/src/app/dashboard/instructor/[id]/page.tsx
+++ b/frontend/src/app/dashboard/instructor/[id]/page.tsx
@@ -260,7 +260,12 @@ export default function EditCourse() {
 
     setInviteCode(result.data.inviteCode ?? null);
     router.refresh();
-    router.push("/dashboard/instructor");
+    notifications.show({
+      id: "course-saved",
+      color: "teal",
+      title: "Saved",
+      message: "Course updated.",
+    });
   }
 
   async function handleDelete() {

--- a/frontend/src/app/dashboard/instructor/labs/[id]/page.tsx
+++ b/frontend/src/app/dashboard/instructor/labs/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   Title,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
 import { IconArrowLeft, IconTrash } from "@tabler/icons-react";
 import AppButton from "@/src/shared/components/AppButton";
 import {
@@ -146,8 +147,15 @@ export default function EditLab() {
       return;
     }
 
+    setInitialStatus(formValues.status);
+    setSavedDockerImage(trimmedDockerImage);
     router.refresh();
-    router.push("/dashboard/instructor/labs");
+    notifications.show({
+      id: "lab-saved",
+      color: "teal",
+      title: "Saved",
+      message: "Lab updated.",
+    });
   }
 
   async function handleSubmit() {

--- a/frontend/src/app/dashboard/instructor/labs/create/page.tsx
+++ b/frontend/src/app/dashboard/instructor/labs/create/page.tsx
@@ -115,7 +115,7 @@ export default function CreateLab() {
     }
 
     router.refresh();
-    router.push("/dashboard/instructor/labs");
+    router.push(`/dashboard/instructor/labs/${result.data.id}`);
   }
 
   return (


### PR DESCRIPTION
- Allow invite-code regeneration on non-PRIVATE courses so owners can generate the code immediately after toggling visibility to Private, without an extra save round-trip.
- Keep instructors on the course/lab detail page after saving (toast notification instead of redirect to the list view).
- After creating a lab, redirect to the new lab's detail/edit page, mirroring the existing course-create flow.