### PR TITLE
fix: render dashboard shell when API client cannot be built

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -231,13 +231,28 @@ export default async function Home() {
   const name = session?.user?.name ?? "there";
   const firstName = name.split(" ")[0];
   const userId = session?.userId ?? undefined;
-  const client = await getApiClient();
+  // Token refresh may fail (expired session, revoked refresh token, Keycloak
+  // restart). In that case we still render the dashboard shell so the
+  // client-side SessionErrorHandler can pick up `session.error` and sign the
+  // user out. Throwing here would crash the page before that ever runs.
+  let client: ApiClient | null = null;
+  try {
+    client = await getApiClient();
+  } catch {
+    client = null;
+  }
   const result = await fetchEnrolledCoursesOfLoggedInUser(0, 3);
-  const [deadlines, completedLabsCount, runningPods] = await Promise.all([
-    fetchMyDeadlines(client),
-    fetchCompletedLabsCount(client),
-    fetchMyRunningPods(client),
-  ]);
+  const [deadlines, completedLabsCount, runningPods]: [
+    DeadlineItem[],
+    number | null,
+    RunningPod[],
+  ] = client
+    ? await Promise.all([
+        fetchMyDeadlines(client),
+        fetchCompletedLabsCount(client),
+        fetchMyRunningPods(client),
+      ])
+    : [[], null, []];
 
   const today = new Date();
   const dateStr = today.toLocaleDateString("en-GB", {


### PR DESCRIPTION
Wrap getApiClient() in Home() with try/catch and fall back to empty data when the call fails (expired session, revoked refresh token, Keycloak unreachable). Previously the helpers each had their own try/catch around getApiClient; the earlier optimisation moved the call out of those guards, so a token-refresh failure crashed the server render before SessionErrorHandler had a chance to sign the user out and redirect to /.