### PR TITLE
Add rewrites and forward proxy headers

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,30 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  rewrites() {
+    return Promise.resolve([
+      {
+        source: "/scalar",
+        destination: "/api/backend/scalar",
+      },
+      {
+        source: "/scalar/:path*",
+        destination: "/api/backend/scalar/:path*",
+      },
+      {
+        source: "/v3/api-docs",
+        destination: "/api/backend/v3/api-docs",
+      },
+      {
+        source: "/v3/api-docs/:path*",
+        destination: "/api/backend/v3/api-docs/:path*",
+      },
+      {
+        source: "/v3/api-docs.yaml",
+        destination: "/api/backend/v3/api-docs.yaml",
+      },
+    ]);
+  },
   turbopack: {
     root: process.cwd(),
   },

--- a/frontend/src/app/api/backend/[...path]/route.ts
+++ b/frontend/src/app/api/backend/[...path]/route.ts
@@ -30,8 +30,16 @@ async function proxy(req: NextRequest, params: { path: string[] }): Promise<Resp
   const body = req.method !== "GET" && req.method !== "HEAD" ? await req.text() : undefined;
   const fetchBackend = (token: string) => {
     const proxyHeaders = new Headers();
+    const accept = req.headers.get("accept");
+    const forwardedHost = req.headers.get("x-forwarded-host") ?? req.headers.get("host");
+    const forwardedProto =
+      req.headers.get("x-forwarded-proto") ?? req.nextUrl.protocol.replace(":", "");
+
     proxyHeaders.set("Authorization", `Bearer ${token}`);
     proxyHeaders.set("Content-Type", "application/json");
+    if (accept) proxyHeaders.set("Accept", accept);
+    if (forwardedHost) proxyHeaders.set("X-Forwarded-Host", forwardedHost);
+    if (forwardedProto) proxyHeaders.set("X-Forwarded-Proto", forwardedProto);
 
     return fetch(targetUrl, {
       method: req.method,


### PR DESCRIPTION
Add Next.js rewrites to route /scalar and /v3/api-docs (and variants) to the backend API endpoints. Update the backend proxy route to forward the original Accept header and X-Forwarded-Host / X-Forwarded-Proto (falling back to Host and req.nextUrl.protocol) so the backend receives the original host/protocol context when handling proxied requests.